### PR TITLE
Report cart change events only on user interactions

### DIFF
--- a/core/src/main/java/io/snabble/sdk/Events.java
+++ b/core/src/main/java/io/snabble/sdk/Events.java
@@ -50,16 +50,10 @@ public class Events {
         this.shoppingCart = shoppingCart;
 
         project.getShoppingCart().addListener(new ShoppingCart.SimpleShoppingCartListener() {
+
             @Override
             public void onChanged(ShoppingCart cart) {
-                if (cartId != null && !cart.getId().equals(cartId)) {
-                    PayloadSessionEnd payloadSessionEnd = new PayloadSessionEnd();
-                    payloadSessionEnd.session = cartId;
-                    post(payloadSessionEnd, false);
-                    cartId = cart.getId();
-                    hasSentSessionStart = false;
-                    return;
-                }
+                updateShop(Snabble.getInstance().getCheckedInShop());
 
                 if (shop != null) {
                     if (!hasSentSessionStart) {
@@ -67,9 +61,40 @@ public class Events {
                         payloadSessionStart.session = cartId;
                         post(payloadSessionStart, false);
                     }
-
                     post(Events.this.project.getShoppingCart().toBackendCart(), true);
                 }
+            }
+
+            @Override
+            public void onCleared(ShoppingCart cart) {
+                final boolean isSameCartWithNewId = shoppingCart == cart && !cart.getId().equals(cartId);
+                if (isSameCartWithNewId) {
+                    PayloadSessionEnd payloadSessionEnd = new PayloadSessionEnd();
+                    payloadSessionEnd.session = cartId;
+                    post(payloadSessionEnd, false);
+                    cartId = cart.getId();
+                    hasSentSessionStart = false;
+                }
+            }
+
+            @Override
+            public void onProductsUpdated(ShoppingCart list) {
+                // Override because it shouldn't trigger onChanged(Cart)
+            }
+
+            @Override
+            public void onPricesUpdated(ShoppingCart list) {
+                // Override because it shouldn't trigger onChanged(Cart)
+            }
+
+            @Override
+            public void onTaxationChanged(ShoppingCart list, ShoppingCart.Taxation taxation) {
+                // Override because it shouldn't trigger onChanged(Cart)
+            }
+
+            @Override
+            public void onCartDataChanged(ShoppingCart list) {
+                // Override because it shouldn't trigger onChanged(Cart)
             }
         });
     }
@@ -83,6 +108,7 @@ public class Events {
             shop = newShop;
         } else {
             shop = null;
+            cartId = null;
             hasSentSessionStart = false;
         }
     }

--- a/core/src/main/java/io/snabble/sdk/ShoppingCart.java
+++ b/core/src/main/java/io/snabble/sdk/ShoppingCart.java
@@ -1560,10 +1560,8 @@ public class ShoppingCart implements Iterable<ShoppingCart.Item> {
         updateTimestamp();
 
         Dispatch.mainThread(() -> {
-            if (list.data.items.contains(item)) {
-                for (ShoppingCartListener listener : listeners) {
-                    listener.onItemRemoved(list, item, pos);
-                }
+            for (ShoppingCartListener listener : listeners) {
+                listener.onItemRemoved(list, item, pos);
             }
         });
     }


### PR DESCRIPTION
Cart events should only be reported on actual user interactions and not on cart changes triggered by updates from background tasks or on SDK initialization.

To achieve this behaviour the number of `ShoppingCartListener.onChanged(Cart)` calls has been reduced drastically and checks has been adjusted to match `Event.post(...)` calls with user interactions.

#### Test instructions

To test the new behavior the app add logging/debugging to the `Event.post(...)` calls and check into a store to interact with the cart:

* add products to the cart _(discount items trigger another `Event.post(...)`, which is fine)_
* remove products to the cart
* empty the cart
* increase quantity
* decrease quantity
* checkout

All and only the interactions from above should lead to `Event.post(...)` calls.