### PR TITLE
Re-add removed sourceSets from ui-toolkit/build.gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.69.1-beta02]
+
+### Fixed
+- Added accidentally removed sourceSets from ui-toolkit/build.gradle
+
 ## [0.69.1-beta01]
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
     }
 
     project.ext {
-        sdkVersion = '0.69.1-beta01'
+        sdkVersion = '0.69.1-beta02'
         versionCode = 1
 
         compileSdkVersion = 31

--- a/ui-toolkit/build.gradle
+++ b/ui-toolkit/build.gradle
@@ -33,6 +33,12 @@ android {
         }
     }
 
+    sourceSets {
+        getByName("main").java.srcDirs("src/main/kotlin")
+        getByName("test").java.srcDirs("src/test/kotlin")
+        getByName("androidTest").java.srcDirs("src/androidTest/kotlin")
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
`sourceSets` are necessary because otherwise non-compile files won't be recognized in artifacts.