### PR TITLE
Fix crash on empty project list in CustomerCard

### DIFF
--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/customercard/usecases/HasCustomerCardUseCase.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/customercard/usecases/HasCustomerCardUseCase.kt
@@ -8,8 +8,8 @@ internal interface HasCustomerCardUseCase {
 }
 
 internal class HasCustomerCardUseCaseImpl(
-    private val Snabble: Snabble,
+    private val snabble: Snabble,
 ) : HasCustomerCardUseCase {
 
-    override operator fun invoke(): Boolean = Snabble.projects.first().customerCardInfo.isNotEmpty()
+    override operator fun invoke(): Boolean = snabble.projects.firstOrNull()?.customerCardInfo?.isNotEmpty() == true
 }

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/locationpermission/usecases/HasLocationPermissionUseCase.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/locationpermission/usecases/HasLocationPermissionUseCase.kt
@@ -9,12 +9,12 @@ internal interface HasLocationPermissionUseCase {
 }
 
 internal class HasLocationPermissionUseCaseImpl(
-    private val Snabble: Snabble,
+    private val snabble: Snabble,
 ) : HasLocationPermissionUseCase {
 
     override operator fun invoke(): Boolean =
         try {
-            Snabble.checkInLocationManager.checkLocationPermission()
+            snabble.checkInLocationManager.checkLocationPermission()
         } catch (e: UninitializedPropertyAccessException) {
             Log.d(this.javaClass.name, "invokeError: ${e.message} ")
             true

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/locationpermission/usecases/UpdateCheckInManagerUseCase.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/locationpermission/usecases/UpdateCheckInManagerUseCase.kt
@@ -10,15 +10,15 @@ internal interface UpdateCheckInManagerUseCase {
 
 internal class UpdateCheckInManagerUseCaseImpl(
     private val hasLocationPermission: HasLocationPermissionUseCase,
-    private val Snabble: Snabble,
+    private val snabble: Snabble,
 ) : UpdateCheckInManagerUseCase {
 
     @SuppressLint("MissingPermission")
     override operator fun invoke() {
         if (hasLocationPermission()) {
-            Snabble.checkInManager.startUpdating()
+            snabble.checkInManager.startUpdating()
         } else {
-            Snabble.checkInManager.stopUpdating()
+            snabble.checkInManager.stopUpdating()
         }
     }
 }

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/di/Module.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/di/Module.kt
@@ -4,6 +4,8 @@ import io.snabble.sdk.widgets.snabble.purchase.RelativeTimeStringFormatter
 import io.snabble.sdk.widgets.snabble.purchase.RelativeTimeStringFormatterImpl
 import io.snabble.sdk.widgets.snabble.purchase.repository.PurchasesRepository
 import io.snabble.sdk.widgets.snabble.purchase.repository.PurchasesRepositoryImpl
+import io.snabble.sdk.widgets.snabble.purchase.usecases.GetPurchasesUseCase
+import io.snabble.sdk.widgets.snabble.purchase.usecases.GetPurchasesUseCaseImpl
 import io.snabble.sdk.widgets.snabble.purchase.viewmodel.PurchaseViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.factoryOf
@@ -13,9 +15,11 @@ import org.koin.dsl.module
 internal val purchaseWidgetModule = module {
     viewModelOf(::PurchaseViewModel)
 
+    factoryOf(::GetPurchasesUseCaseImpl) bind GetPurchasesUseCase::class
+
     factory {
         PurchasesRepositoryImpl(
-            Snabble = get(),
+            snabble = get(),
             timeFormatter = get(),
         )
     } bind PurchasesRepository::class

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/repository/PurchasesRepository.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/repository/PurchasesRepository.kt
@@ -18,14 +18,14 @@ internal interface PurchasesRepository {
 }
 
 internal class PurchasesRepositoryImpl(
-    private val Snabble: Snabble,
+    private val snabble: Snabble,
     private val timeFormatter: RelativeTimeStringFormatter,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : PurchasesRepository {
 
     override suspend fun getPurchases(count: Int): List<Purchase> = withContext(ioDispatcher) {
         suspendCancellableCoroutine { continuation ->
-            Snabble.receipts.getReceiptInfo(object : Receipts.ReceiptInfoCallback {
+            snabble.receipts.getReceiptInfo(object : Receipts.ReceiptInfoCallback {
 
                 override fun success(receiptInfos: Array<ReceiptInfo>?) {
                     if (!continuation.isActive) return

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/usecases/GetPurchasesUseCase.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/usecases/GetPurchasesUseCase.kt
@@ -1,0 +1,16 @@
+package io.snabble.sdk.widgets.snabble.purchase.usecases
+
+import io.snabble.sdk.widgets.snabble.purchase.Purchase
+import io.snabble.sdk.widgets.snabble.purchase.repository.PurchasesRepository
+
+internal interface GetPurchasesUseCase {
+
+    suspend operator fun invoke(count: Int): List<Purchase>
+}
+
+internal class GetPurchasesUseCaseImpl(
+    private val repo: PurchasesRepository,
+) : GetPurchasesUseCase {
+
+    override suspend fun invoke(count: Int): List<Purchase> = repo.getPurchases(count)
+}

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/viewmodel/PurchaseViewModel.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/viewmodel/PurchaseViewModel.kt
@@ -3,13 +3,13 @@ package io.snabble.sdk.widgets.snabble.purchase.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.snabble.sdk.widgets.snabble.purchase.Purchase
-import io.snabble.sdk.widgets.snabble.purchase.repository.PurchasesRepository
+import io.snabble.sdk.widgets.snabble.purchase.usecases.GetPurchasesUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 internal class PurchaseViewModel(
-    private val repo: PurchasesRepository,
+    private val getPurchases: GetPurchasesUseCase,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<State>(Loading)
@@ -22,7 +22,7 @@ internal class PurchaseViewModel(
         }
     }
 
-    private suspend fun loadPurchases(): List<Purchase> = repo.getPurchases(count = 2)
+    private suspend fun loadPurchases(): List<Purchase> = getPurchases(count = 2)
 }
 
 internal sealed class State

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/stores/viewmodel/StoresViewModel.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/stores/viewmodel/StoresViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 internal class StoresViewModel(
-    private val Snabble: Snabble,
+    private val snabble: Snabble,
 ) : ViewModel() {
 
     private val _isCheckedInFlow = MutableStateFlow(false)
@@ -19,11 +19,11 @@ internal class StoresViewModel(
     }
 
     init {
-        Snabble.currentCheckedInShop.observeForever(isCheckedInObserver)
+        snabble.currentCheckedInShop.observeForever(isCheckedInObserver)
     }
 
     override fun onCleared() {
-        Snabble.currentCheckedInShop.removeObserver(isCheckedInObserver)
+        snabble.currentCheckedInShop.removeObserver(isCheckedInObserver)
 
         super.onCleared()
     }

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/wlan/usecases/HasWlanConnectionUseCase.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/wlan/usecases/HasWlanConnectionUseCase.kt
@@ -12,13 +12,13 @@ internal interface HasWlanConnectionUseCase {
 }
 
 internal class HasWlanConnectionUseCaseImpl(
-    private val Snabble: Snabble,
+    private val snabble: Snabble,
     private val wifiManager: WifiManager,
     private val connectivityManager: ConnectivityManager,
 ) : HasWlanConnectionUseCase {
 
     override operator fun invoke(): Boolean =
-        Snabble.currentCheckedInShop.value != null
+        snabble.currentCheckedInShop.value != null
                 && wifiManager.isWifiEnabled
                 && !isConnectedToStoreWifi()
 


### PR DESCRIPTION
`Snabble.projects` might be empty so `List.first()` will crash. To prevent that the `HasCustomerCardUseCaseImpl` will now use `List.firstOrNull()`.

#### Additionally:
* the constructor parameter `val Snabble: Snabble` now start with a lower case `s`.
* The _PurchaseViewModel_ makes now use of a new _GetPurchasesUseCase_ instead of using the repo directly.