### PR TITLE
Refactored fix for null cart app crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 * Added payment method PAYONE SEPA
 
+### Changed
+* Set the cart adapter after a project change (different fix for the same bug from #90)
+
 ## [0.69.1-beta07]
 ### Fixed
 * Fixed navigation when using manual product search

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/ShoppingCartView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/ShoppingCartView.java
@@ -626,8 +626,6 @@ public class ShoppingCartView extends FrameLayout {
 
         // for fetching the data from outside of this view
         public void fetchFrom(ShoppingCart cart) {
-            this.cart = cart;
-
             hasAnyImages = false;
 
             for (int i = 0; i < cart.size(); i++) {

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/CombinedScannerFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/CombinedScannerFragment.kt
@@ -88,6 +88,9 @@ class CombinedScannerFragment : SelfScanningFragment() {
         Snabble.checkedInProject.observe(viewLifecycleOwner) { project ->
             project?.let {
                 scannerBottomSheetView.cart = it.shoppingCart
+
+                val cartAdapter = ShoppingCartView.ShoppingCartAdapter(scannerBottomSheetView, it.shoppingCart)
+                scannerBottomSheetView.shoppingCartAdapter = cartAdapter
             }
         }
         scannerBottomSheetView.behavior = ScannerBottomSheetBehavior(scannerBottomSheetView).apply {
@@ -118,9 +121,6 @@ class CombinedScannerFragment : SelfScanningFragment() {
                 }
         }
 
-        val cartAdapter = ShoppingCartView.ShoppingCartAdapter(scannerBottomSheetView, cart)
-
-        scannerBottomSheetView.shoppingCartAdapter = cartAdapter
         scannerBottomSheetView.onItemsChangedListener += ::cartChanged
         createItemTouchHelper()
     }


### PR DESCRIPTION
Refactored the fix from #90.  
The cart is now again only set on adapter creation, but the adapter is created and set after a project checkin/change.
