### PR TITLE
Adjust barcode detection area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Added
 ### Changed
+* ui: Adjust detection rect implementation
+* ui: Speed up ZXing's barcode by using TRY_HARDER mode
+
 ### Removed
 ### Fixed
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -54,6 +54,8 @@ android {
 }
 
 dependencies {
+    def kotest_version = '5.4.0'
+
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${project.desugarVersion}"
 
     implementation project(':utils')
@@ -91,7 +93,7 @@ dependencies {
     //noinspection GradleDependency
     implementation 'commons-io:commons-io:2.5'
     //noinspection GradleDependency
-    implementation 'com.google.zxing:core:3.3.3'
+    implementation 'com.google.zxing:core:3.5.1'
     implementation 'com.squareup.picasso:picasso:2.8'
 
     androidTestImplementation 'androidx.test:runner:1.4.0'
@@ -112,4 +114,14 @@ dependencies {
 
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha02'
+
+    testImplementation "io.kotest:kotest-runner-junit5:$kotest_version"
+    testImplementation "io.kotest:kotest-assertions-core:$kotest_version"
+    testImplementation 'io.mockk:mockk:1.13.3'
+}
+
+android.testOptions {
+    unitTests.all {
+        useJUnitPlatform()
+    }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/CropRect.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/CropRect.kt
@@ -1,0 +1,37 @@
+package io.snabble.sdk.ui.scanner
+
+import android.graphics.Rect
+
+data class CropRect(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int
+) {
+
+    companion object {
+
+        fun from(
+            width: Int,
+            height: Int,
+            scanRectHeight: Float
+        ): CropRect {
+            val actualWidth: Int = maxOf(width, height)
+            val actualHeight: Int = minOf(width, height)
+
+            val scanAreaStart = actualWidth * CENTER_FRACTION - actualWidth * scanRectHeight * CENTER_FRACTION
+            val scanAreaEnd = actualWidth * CENTER_FRACTION + actualWidth * scanRectHeight * CENTER_FRACTION
+
+            val isLandscape = width >= height
+            return if (isLandscape) {
+                CropRect(scanAreaStart.toInt(), 0, scanAreaEnd.toInt(), actualHeight)
+            } else {
+                CropRect(0, scanAreaStart.toInt(), actualHeight, scanAreaEnd.toInt())
+            }
+        }
+
+        private const val CENTER_FRACTION = .5f
+    }
+}
+
+fun CropRect.toRect(): Rect = Rect(this.left, this.top, this.right, this.bottom)

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/CropRect.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/CropRect.kt
@@ -2,11 +2,11 @@ package io.snabble.sdk.ui.scanner
 
 import android.graphics.Rect
 
-data class CropRect(
+internal data class CropRect(
     val left: Int,
     val top: Int,
     val right: Int,
-    val bottom: Int
+    val bottom: Int,
 ) {
 
     companion object {
@@ -14,7 +14,7 @@ data class CropRect(
         fun from(
             width: Int,
             height: Int,
-            scanRectHeight: Float
+            scanRectHeight: Float,
         ): CropRect {
             val actualWidth: Int = maxOf(width, height)
             val actualHeight: Int = minOf(width, height)
@@ -34,4 +34,4 @@ data class CropRect(
     }
 }
 
-fun CropRect.toRect(): Rect = Rect(this.left, this.top, this.right, this.bottom)
+internal fun CropRect.toRect(): Rect = Rect(this.left, this.top, this.right, this.bottom)

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/ZXingBarcodeDetector.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/ZXingBarcodeDetector.java
@@ -38,6 +38,7 @@ public class ZXingBarcodeDetector implements BarcodeDetector {
         }
 
         hints.put(DecodeHintType.POSSIBLE_FORMATS, formats);
+        hints.put(DecodeHintType.TRY_HARDER, null);
         multiFormatReader.setHints(hints);
     }
 
@@ -48,9 +49,9 @@ public class ZXingBarcodeDetector implements BarcodeDetector {
 
     @Override
     public Barcode detect(byte[] data, int width, int height, int bitsPerPixel, Rect detectionRect, int displayOrientation) {
-        Result result = detectInternal(data, width, height, bitsPerPixel, detectionRect, displayOrientation, false);
+        Result result = detectInternal(data, width, bitsPerPixel, detectionRect, displayOrientation, false);
         if (result == null) {
-            result = detectInternal(data, width, height, bitsPerPixel, detectionRect, displayOrientation, true);
+            result = detectInternal(data, width, bitsPerPixel, detectionRect, displayOrientation, true);
         }
 
         if (result != null) {
@@ -82,8 +83,8 @@ public class ZXingBarcodeDetector implements BarcodeDetector {
         return null;
     }
 
-    private Result detectInternal(byte[] data, int width, int height, int bitsPerPixel, Rect detectionRect, int displayOrientation, boolean rotate) {
-        byte[] buf = getRotatedData(data, width, height, bitsPerPixel, detectionRect, displayOrientation, rotate);
+    private Result detectInternal(byte[] data, int width, int bitsPerPixel, Rect detectionRect, int displayOrientation, boolean rotate) {
+        byte[] buf = getRotatedData(data, width, bitsPerPixel, detectionRect, displayOrientation, rotate);
 
         int tWidth = detectionRect.width();
         int tHeight = detectionRect.height();
@@ -114,7 +115,7 @@ public class ZXingBarcodeDetector implements BarcodeDetector {
         return null;
     }
 
-    private byte[] getRotatedData(byte[] data, int width, int height, int bitsPerPixel, Rect detectionRect, int displayOrientation, boolean rotate90deg) {
+    private byte[] getRotatedData(byte[] data, int width, int bitsPerPixel, Rect detectionRect, int displayOrientation, boolean rotate90deg) {
         int size = detectionRect.width() * detectionRect.height() * bitsPerPixel / 8;
         if (cropBuffer == null || cropBuffer.length != size) {
             cropBuffer = new byte[size];
@@ -128,18 +129,6 @@ public class ZXingBarcodeDetector implements BarcodeDetector {
         int bottom = detectionRect.bottom;
 
         int tWidth = detectionRect.width();
-        int tHeight = detectionRect.height();
-
-        // special cases for reversed orientations, we don't flip the image
-        // because zxing is able to detect flipped images
-        // but we need to adjust the camera region
-        if (displayOrientation == 180) { // reverse-landscape
-            top = height - top - tHeight;
-            bottom = top + tHeight;
-        } else if (displayOrientation == 270) { // reverse-portrait
-            left = width - left - tWidth;
-            right = left + tWidth;
-        }
 
         if (rotate90deg) {
             int i = 0;

--- a/ui/src/test/java/io/snabble/sdk/ui/scanner/CropRectTest.kt
+++ b/ui/src/test/java/io/snabble/sdk/ui/scanner/CropRectTest.kt
@@ -7,7 +7,7 @@ class CropRectTest : FreeSpec({
 
     "An image w/ the size 1280x720" - {
 
-        "should product a CropRect w/ scanRectHeight" - {
+        "should produce a CropRect w/ scanRectHeight" - {
 
             "1/2 of the size 640x720" {
                 val cropRect = CropRect.from(width = 1280, height = 720, scanRectHeight = 1 / 2f)
@@ -26,7 +26,7 @@ class CropRectTest : FreeSpec({
 
     "An image w/ the size 720x1280" - {
 
-        "should product a crop rect w/ scanRectHeight " - {
+        "should produce a crop rect w/ scanRectHeight" - {
 
             "1/2 of the size 720x640" {
                 val cropRect = CropRect.from(width = 720, height = 1280, scanRectHeight = 1 / 2f)

--- a/ui/src/test/java/io/snabble/sdk/ui/scanner/CropRectTest.kt
+++ b/ui/src/test/java/io/snabble/sdk/ui/scanner/CropRectTest.kt
@@ -1,0 +1,44 @@
+package io.snabble.sdk.ui.scanner
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class CropRectTest : FreeSpec({
+
+    "An image w/ the size 1280x720" - {
+
+        "should product a CropRect w/ scanRectHeight" - {
+
+            "1/2 of the size 640x720" {
+                val cropRect = CropRect.from(width = 1280, height = 720, scanRectHeight = 1 / 2f)
+
+                cropRect shouldBe CropRect(left = 320, top = 0, right = 960, bottom = 720)
+            }
+
+            "2/3 of the size 853x720" {
+                val cropRect = CropRect.from(width = 1280, height = 720, scanRectHeight = 2 / 3f)
+
+                cropRect shouldBe CropRect(left = 213, top = 0, right = 1066, bottom = 720)
+            }
+        }
+
+    }
+
+    "An image w/ the size 720x1280" - {
+
+        "should product a crop rect w/ scanRectHeight " - {
+
+            "1/2 of the size 720x640" {
+                val cropRect = CropRect.from(width = 720, height = 1280, scanRectHeight = 1 / 2f)
+
+                cropRect shouldBe CropRect(left = 0, top = 320, right = 720, bottom = 960)
+            }
+
+            "1/3 of the size 720x853" {
+                val cropRect = CropRect.from(width = 720, height = 1280, scanRectHeight = 2 / 3f)
+
+                cropRect shouldBe CropRect(left = 0, top = 213, right = 720, bottom = 1066)
+            }
+        }
+    }
+})


### PR DESCRIPTION
Check for orientation of the camera image and calculate a detection area rect regarding the camera image's orientation.

Making now use of ZXing `TRY_HARDER` mode and removed unreachable code.

Improved overall readability by smaller refactorings.
