### PR TITLE
Fix add IBAN crash by implementing Serializable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+* core: Fix add IBAN crash by implementing missing Serializable interface
 
 ## [0.69.3]
 ### Changed

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -10,6 +10,7 @@ import io.snabble.sdk.Product
 import io.snabble.sdk.coupons.Coupon
 import io.snabble.sdk.FulfillmentState
 import io.snabble.sdk.PaymentMethod
+import java.io.Serializable
 import java.lang.Exception
 import java.util.*
 
@@ -142,7 +143,7 @@ enum class RoutingTarget {
 
 data class Href(
     val href: String? = null,
-)
+) : Serializable
 
 data class SignedCheckoutInfo(
     val checkoutInfo: JsonObject? = null,


### PR DESCRIPTION
The _add IBAN_ feature after an successful checkout was broken due to an missing `java.io.Serializable` implementation. The missing implementation led to an exception on attempting to serialize the PaymentOriginCandidate into a bundle.
