### PR TITLE
Fix serialization exception for payment origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Add release on tag
 ### Removed
 ### Fixed
+* Serialization Exception due to usage of com.google.gson.internal.LinkedTreeMap
 
 ## [0.69.6]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Added
 ### Changed
+### Removed
+### Fixed
+
+## [0.69.7]
+### Changed
 * Convert all grade files to gradle.kts files
 * Add version catalog and dependency update plugin
 * Add release on tag
-### Removed
+
 ### Fixed
 * Serialization Exception due to usage of com.google.gson.internal.LinkedTreeMap
 
@@ -24,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ## [0.69.4]
 ### Added
 * ui: Pre-fill IBAN for PAYONE SEPA after checkout
+
 ### Fixed
 * core: Fix add IBAN crash by implementing missing Serializable interface
 * ui: Fix PAYONE SEPA country code ui


### PR DESCRIPTION
Fixed a serialization exception due to usage of removed _com.google.gson.internal.LinkedTreeMap_.
_java.util.LinkedHashMap_ will be used instead.
