### PR TITLE
Add toolbar and option for checkout activity

### DIFF
--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -122,9 +122,9 @@ class CheckoutActivity : FragmentActivity() {
 
     private fun setUpToolBarAndStatusBar() {
         val showToolBar = resources.getBoolean(R.bool.showToolbarInCheckout)
-        findViewById<View>(R.id.checkout_toolbar_spacer).isVisible = showToolBar
+        findViewById<View>(R.id.checkout_toolbar_spacer)?.isVisible = showToolBar
         navController.addOnDestinationChangedListener { _, destination, arguments ->
-            findViewById<View>(R.id.checkout_toolbar).isVisible = arguments?.getBoolean("showToolbar", false) == true
+            findViewById<View>(R.id.checkout_toolbar)?.isVisible = arguments?.getBoolean("showToolbar", false) == true
         }
         if (showToolBar) {
             applyInsets()
@@ -195,31 +195,32 @@ class CheckoutActivity : FragmentActivity() {
     }
 
     private fun applyInsets() {
+        val root = findViewById<View>(R.id.root) ?: return
+
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        val root = findViewById<View>(R.id.root)
         val windowInsetsController = WindowInsetsControllerCompat(window, root)
 
         ViewCompat.setOnApplyWindowInsetsListener(root) { view, windowInsets ->
             window.statusBarColor = Color.parseColor("#22000000")
             windowInsetsController.isAppearanceLightStatusBars = false
 
-            val types = mutableListOf<Int>().apply {
-                add(WindowInsetsCompat.Type.navigationBars())
-                add(WindowInsetsCompat.Type.ime())
-                add(WindowInsetsCompat.Type.systemBars())
-                add(WindowInsetsCompat.Type.statusBars())
-            }
-
-            val currentInsetTypeMask = types.fold(0) { accumulator, type -> accumulator or type }
+            val currentInsetTypeMask = listOf(
+                WindowInsetsCompat.Type.navigationBars(),
+                WindowInsetsCompat.Type.ime(),
+                WindowInsetsCompat.Type.systemBars(),
+                WindowInsetsCompat.Type.statusBars()
+            ).fold(0) { accumulator, type -> accumulator or type }
 
             @SuppressLint("WrongConstant")
             val insets = windowInsets.getInsets(currentInsetTypeMask)
             view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 updateMargins(insets.left, 0, insets.right, insets.bottom)
             }
-            val toolbarSpacer = findViewById<View>(R.id.checkout_toolbar_spacer)
-            toolbarSpacer.setPadding(0, insets.top, 0, 0)
+            findViewById<View>(R.id.checkout_toolbar_spacer)?.apply {
+                setPadding(0, insets.top, 0, 0)
+            }
+
             windowInsets.inset(insets.left, insets.top, insets.right, insets.bottom)
         }
     }

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -2,8 +2,11 @@ package io.snabble.sdk.ui.checkout
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.navigation.NavController
@@ -38,8 +41,8 @@ class CheckoutActivity : FragmentActivity() {
         @JvmStatic
         fun restoreCheckoutIfNeeded(context: Context) {
             Snabble.initializationState.observeForever(object : Observer<InitializationState> {
-                override fun onChanged(t: InitializationState) {
-                    if (t == InitializationState.INITIALIZED) {
+                override fun onChanged(value: InitializationState) {
+                    if (value == InitializationState.INITIALIZED) {
                         Snabble.initializationState.removeObserver(this)
                         val project = Snabble.checkedInProject.value
                         if (project?.checkout?.state?.value?.isCheckoutState == true) {
@@ -67,6 +70,7 @@ class CheckoutActivity : FragmentActivity() {
                 InitializationState.INITIALIZED -> {
                     Snabble.checkedInProject.observe(this) { project ->
                         setContentView(R.layout.snabble_activity_checkout)
+                        setUpToolBarAndStatusBar()
 
                         val navHostFragment = supportFragmentManager.findFragmentById(
                             R.id.nav_host_container
@@ -110,6 +114,14 @@ class CheckoutActivity : FragmentActivity() {
                     finishWithError("The snabble SDK is not initialized")
                 }
             }
+        }
+    }
+
+    private fun setUpToolBarAndStatusBar() {
+        val showToolBar = resources.getBoolean(R.bool.showCheckoutToolbar)
+        findViewById<View>(R.id.checkout_toolbar).isVisible = showToolBar
+        if (showToolBar) {
+            window.statusBarColor = Color.parseColor("#06ADC3")
         }
     }
 

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -16,6 +17,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraph
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.navArgs
 import io.snabble.sdk.InitializationState
 import io.snabble.sdk.PaymentMethod
 import io.snabble.sdk.Snabble
@@ -73,7 +75,6 @@ class CheckoutActivity : FragmentActivity() {
                 InitializationState.INITIALIZED -> {
                     Snabble.checkedInProject.observe(this) { project ->
                         setContentView(R.layout.snabble_activity_checkout)
-                        setUpToolBarAndStatusBar()
 
                         val navHostFragment = supportFragmentManager.findFragmentById(
                             R.id.nav_host_container
@@ -81,6 +82,7 @@ class CheckoutActivity : FragmentActivity() {
                         val graphInflater = navHostFragment.navController.navInflater
                         navGraph = graphInflater.inflate(R.navigation.snabble_nav_checkout)
                         navController = navHostFragment.navController
+                        setUpToolBarAndStatusBar()
 
                         if (project == null) {
                             finishWithError("Project not set")
@@ -123,6 +125,9 @@ class CheckoutActivity : FragmentActivity() {
     private fun setUpToolBarAndStatusBar() {
         val showToolBar = resources.getBoolean(R.bool.showCheckoutToolbar)
         findViewById<View>(R.id.checkout_toolbar_spacer).isVisible = showToolBar
+        navController.addOnDestinationChangedListener{_, destination, arguments ->
+            findViewById<View>(R.id.checkout_toolbar).isVisible = arguments?.getBoolean("showToolbar",false) == true
+        }
         if (showToolBar) {
             applyInsets()
         }

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -1,12 +1,15 @@
 package io.snabble.sdk.ui.checkout
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.appcompat.app.AlertDialog
-import androidx.core.view.isVisible
+import androidx.core.view.*
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.navigation.NavController
@@ -119,9 +122,9 @@ class CheckoutActivity : FragmentActivity() {
 
     private fun setUpToolBarAndStatusBar() {
         val showToolBar = resources.getBoolean(R.bool.showCheckoutToolbar)
-        findViewById<View>(R.id.checkout_toolbar).isVisible = showToolBar
+        findViewById<View>(R.id.checkout_toolbar_spacer).isVisible = showToolBar
         if (showToolBar) {
-            window.statusBarColor = Color.parseColor("#06ADC3")
+            applyInsets()
         }
     }
 
@@ -185,6 +188,36 @@ class CheckoutActivity : FragmentActivity() {
                 R.id.snabble_nav_payment_payone_sepa_mandate
             }
             else -> R.id.snabble_nav_payment_status
+        }
+    }
+
+    private fun applyInsets() {
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        val root = findViewById<View>(R.id.root)
+        val windowInsetsController = WindowInsetsControllerCompat(window, root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { view, windowInsets ->
+            window.statusBarColor = Color.parseColor("#22000000")
+            windowInsetsController.isAppearanceLightStatusBars = false
+
+            val types = mutableListOf<Int>().apply {
+                add(WindowInsetsCompat.Type.navigationBars())
+                add(WindowInsetsCompat.Type.ime())
+                add(WindowInsetsCompat.Type.systemBars())
+                add(WindowInsetsCompat.Type.statusBars())
+            }
+
+            val currentInsetTypeMask = types.fold(0) { accumulator, type -> accumulator or type }
+
+            @SuppressLint("WrongConstant")
+            val insets = windowInsets.getInsets(currentInsetTypeMask)
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                updateMargins(insets.left, 0, insets.right, insets.bottom)
+            }
+            val toolbarSpacer = findViewById<View>(R.id.checkout_toolbar_spacer)
+            toolbarSpacer.setPadding(0, insets.top, 0, 0)
+            windowInsets.inset(insets.left, insets.top, insets.right, insets.bottom)
         }
     }
 

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -121,7 +121,7 @@ class CheckoutActivity : FragmentActivity() {
     }
 
     private fun setUpToolBarAndStatusBar() {
-        val showToolBar = resources.getBoolean(R.bool.showCheckoutToolbar)
+        val showToolBar = resources.getBoolean(R.bool.showToolbarInCheckout)
         findViewById<View>(R.id.checkout_toolbar_spacer).isVisible = showToolBar
         navController.addOnDestinationChangedListener { _, destination, arguments ->
             findViewById<View>(R.id.checkout_toolbar).isVisible = arguments?.getBoolean("showToolbar", false) == true

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -17,7 +16,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraph
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.navArgs
 import io.snabble.sdk.InitializationState
 import io.snabble.sdk.PaymentMethod
 import io.snabble.sdk.Snabble
@@ -125,8 +123,8 @@ class CheckoutActivity : FragmentActivity() {
     private fun setUpToolBarAndStatusBar() {
         val showToolBar = resources.getBoolean(R.bool.showCheckoutToolbar)
         findViewById<View>(R.id.checkout_toolbar_spacer).isVisible = showToolBar
-        navController.addOnDestinationChangedListener{_, destination, arguments ->
-            findViewById<View>(R.id.checkout_toolbar).isVisible = arguments?.getBoolean("showToolbar",false) == true
+        navController.addOnDestinationChangedListener { _, destination, arguments ->
+            findViewById<View>(R.id.checkout_toolbar).isVisible = arguments?.getBoolean("showToolbar", false) == true
         }
         if (showToolBar) {
             applyInsets()

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/routingtargets/RoutingTargetGatekeeperView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/routingtargets/RoutingTargetGatekeeperView.kt
@@ -127,10 +127,11 @@ class RoutingTargetGatekeeperView @JvmOverloads constructor(
 
     private fun setHelperImage(bitmap: Bitmap?) {
         val helperImage = helperImage
-        if (helperImage == null) {
-            helperTextNoImage.isVisible = false
+        if (helperImage == null) { // Can be overridden by hosting app using R.layout.snabble_checkout_header
+            helperTextNoImage.isVisible = false // this is not part of the layout thus needs to be hidden
             return
         }
+
         if (bitmap != null) {
             helperImage.setImageBitmap(bitmap)
             helperImage.isVisible = true

--- a/ui/src/main/res/layout/snabble_activity_checkout.xml
+++ b/ui/src/main/res/layout/snabble_activity_checkout.xml
@@ -1,26 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/checkout_toolbar"
+        style="Widget.Material3.Toolbar.Surface"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:title="@string/Snabble.Payment.confirm" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_container"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
-
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/checkout_toolbar"
-            style="Widget.Material3.Toolbar.Surface"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:title="@string/Snabble.Payment.confirm" />
-
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/nav_host_container"
-            android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:defaultNavHost="true" />
-    </LinearLayout>
-</FrameLayout>
+        app:defaultNavHost="true" />
+</LinearLayout>

--- a/ui/src/main/res/layout/snabble_activity_checkout.xml
+++ b/ui/src/main/res/layout/snabble_activity_checkout.xml
@@ -19,7 +19,7 @@
             style="Widget.Material3.Toolbar.Surface"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:title="@string/Snabble.Payment.confirm" />
+            app:title="@string/Snabble.Payment.transferCart" />
     </FrameLayout>
 
     <androidx.fragment.app.FragmentContainerView

--- a/ui/src/main/res/layout/snabble_activity_checkout.xml
+++ b/ui/src/main/res/layout/snabble_activity_checkout.xml
@@ -11,7 +11,7 @@
         android:id="@+id/checkout_toolbar_spacer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/toolbar"
+        android:background="@color/snabble_toolbar"
         android:visibility="gone">
 
         <com.google.android.material.appbar.MaterialToolbar

--- a/ui/src/main/res/layout/snabble_activity_checkout.xml
+++ b/ui/src/main/res/layout/snabble_activity_checkout.xml
@@ -3,10 +3,24 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/nav_host_container"
-        android:name="androidx.navigation.fragment.NavHostFragment"
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:defaultNavHost="true" />
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/checkout_toolbar"
+            style="Widget.Material3.Toolbar.Surface"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/Snabble.Payment.confirm" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_container"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true" />
+    </LinearLayout>
 </FrameLayout>

--- a/ui/src/main/res/layout/snabble_activity_checkout.xml
+++ b/ui/src/main/res/layout/snabble_activity_checkout.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/checkout_toolbar"
-        style="Widget.Material3.Toolbar.Surface"
+    <!-- Workaround for alignment bug in MaterialToolbar when setting padding -->
+    <FrameLayout
+        android:id="@+id/checkout_toolbar_spacer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:title="@string/Snabble.Payment.confirm" />
+        android:background="@color/toolbar"
+        android:visibility="gone">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/checkout_toolbar"
+            style="Widget.Material3.Toolbar.Surface"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/Snabble.Payment.confirm" />
+    </FrameLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_container"

--- a/ui/src/main/res/layout/snabble_checkout_header.xml
+++ b/ui/src/main/res/layout/snabble_checkout_header.xml
@@ -13,7 +13,7 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         tools:ignore="ContentDescription"
-        tools:src="@drawable/snabble_ic_rating_3"
+        tools:src="@drawable/snabble_rating_neutral"
         tools:visibility="visible" />
 
 </merge>

--- a/ui/src/main/res/layout/snabble_view_routing_gatekeeper.xml
+++ b/ui/src/main/res/layout/snabble_view_routing_gatekeeper.xml
@@ -30,7 +30,9 @@
                 android:paddingLeft="16dp"
                 android:paddingRight="16dp"
                 android:text="@string/Snabble.Payment.presentCode"
-                android:textAppearance="?attr/textAppearanceBodyLarge" />
+                android:textAppearance="?attr/textAppearanceBodyLarge"
+                android:visibility="gone"
+                tools:visibility="visible" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/ui/src/main/res/layout/snabble_view_routing_gatekeeper.xml
+++ b/ui/src/main/res/layout/snabble_view_routing_gatekeeper.xml
@@ -25,6 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:layout_marginBottom="20dp"
                 android:gravity="center"
                 android:paddingLeft="16dp"
                 android:paddingRight="16dp"

--- a/ui/src/main/res/navigation/snabble_nav_checkout.xml
+++ b/ui/src/main/res/navigation/snabble_nav_checkout.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/snabble_nav_checkout">
     <fragment
         android:id="@+id/snabble_nav_routing_gatekeeper"
         android:name="io.snabble.sdk.ui.checkout.routingtargets.RoutingTargetGatekeeperFragment"
-        android:label="@string/Snabble.Checkout.title" />
+        android:label="@string/Snabble.Checkout.title" >
+        <argument
+            android:name="showToolbar"
+            android:defaultValue="true"
+            app:argType="boolean" />
+    </fragment>
 
     <fragment
         android:id="@+id/snabble_nav_routing_supervisor"

--- a/ui/src/main/res/navigation/snabble_nav_checkout.xml
+++ b/ui/src/main/res/navigation/snabble_nav_checkout.xml
@@ -5,7 +5,7 @@
     <fragment
         android:id="@+id/snabble_nav_routing_gatekeeper"
         android:name="io.snabble.sdk.ui.checkout.routingtargets.RoutingTargetGatekeeperFragment"
-        android:label="@string/Snabble.Checkout.title" >
+        android:label="@string/Snabble.Checkout.title">
         <argument
             android:name="showToolbar"
             android:defaultValue="true"

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -160,6 +160,7 @@
     <string name="Snabble.Payment.SEPA.title">SEPA-Lastschrift</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Gültige IBAN</string>
     <string name="Snabble.Payment.success">Vielen Dank für deinen Einkauf</string>
+    <string name="Snabble.Payment.transferCart">Warenkorb übertragen</string>
     <string name="Snabble.Payment.Twint.error">Bei der Verarbeitung deines TWINT-Accounts ist ein Fehler aufgetreten</string>
     <string name="Snabble.Payment.usableAt">Verwendbar bei: %s</string>
     <string name="Snabble.Payment.waiting">Warte auf Bestätigung</string>

--- a/ui/src/main/res/values-fr-rCH/strings.xml
+++ b/ui/src/main/res/values-fr-rCH/strings.xml
@@ -164,6 +164,7 @@
     <string name="Snabble.Payment.SEPA.title">Débit SEPA</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Valid IBAN</string>
     <string name="Snabble.Payment.success">Merci pour ton achat !</string>
+    <string name="Snabble.Payment.transferCart">Transfer shopping cart</string>
     <string name="Snabble.Payment.Twint.error">Une erreur s’est produite lors du traitement de ton compte TWINT</string>
     <string name="Snabble.Payment.usableAt">Utilisable pour : %s</string>
     <string name="Snabble.Payment.waiting">Attends la confirmation</string>

--- a/ui/src/main/res/values-fr/strings.xml
+++ b/ui/src/main/res/values-fr/strings.xml
@@ -164,6 +164,7 @@
     <string name="Snabble.Payment.SEPA.title">Prélèvement SEPA</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Valid IBAN</string>
     <string name="Snabble.Payment.success">Merci beaucoup pour votre achat</string>
+    <string name="Snabble.Payment.transferCart">Transfer shopping cart</string>
     <string name="Snabble.Payment.Twint.error">Une erreur est survenue lors du traitement de votre compte TWINT.</string>
     <string name="Snabble.Payment.usableAt">À utiliser jusqu\'au : %s</string>
     <string name="Snabble.Payment.waiting">En attente de confirmation</string>

--- a/ui/src/main/res/values-hu/strings.xml
+++ b/ui/src/main/res/values-hu/strings.xml
@@ -160,6 +160,7 @@
     <string name="Snabble.Payment.SEPA.title">SEPA terhelési megbízás</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Érvényes IBAN</string>
     <string name="Snabble.Payment.success">Köszönjük a vásárlásodat</string>
+    <string name="Snabble.Payment.transferCart">Kosár továbbítása</string>
     <string name="Snabble.Payment.Twint.error">A TWINT-fiókod feldolgozása során hiba történt</string>
     <string name="Snabble.Payment.usableAt">Itt használható: %s</string>
     <string name="Snabble.Payment.waiting">Várj a nyugtázásra</string>
@@ -193,13 +194,13 @@
     <string name="Snabble.PaymentStatus.Payment.title">Fizetés</string>
     <string name="Snabble.PaymentStatus.Payment.tryAgain">Megpróbálom újra</string>
     <!-- Button to submit the feedback on the checkout screen after a successful checkout. -->
-    <string name="Snabble.PaymentStatus.Rating.send">Elküldés</string>
+    <string name="Snabble.PaymentStatus.Rating.send">Visszajelzés elküldése</string>
     <string name="Snabble.PaymentStatus.Rating.title">Mi nem volt jó?</string>
     <string name="Snabble.PaymentStatus.Rating.title2">Mit tudnánk még jobban csinálni?</string>
     <!-- Placeholder text in the input text field on the checkout screen after a successful checkout. -->
-    <string name="Snabble.PaymentStatus.Ratings.feedbackPlaceholder">Feel free to give us more feedback (optional)</string>
+    <string name="Snabble.PaymentStatus.Ratings.feedbackPlaceholder">Szívesen fogadjuk további visszajelzésedet (opcionális)</string>
     <string name="Snabble.PaymentStatus.Ratings.thanks">Köszönjük!</string>
-    <string name="Snabble.PaymentStatus.Ratings.thanksForFeedback">Thanks for your feedback!</string>
+    <string name="Snabble.PaymentStatus.Ratings.thanksForFeedback">Köszönjük a visszajelzésedet!</string>
     <string name="Snabble.PaymentStatus.Ratings.title">Tetszett a vásárlás?</string>
     <string name="Snabble.PaymentStatus.Receipt.title">Nyugta</string>
     <string name="Snabble.PaymentStatus.step1">Helymeghatározás a pénztár területén</string>

--- a/ui/src/main/res/values-it/strings.xml
+++ b/ui/src/main/res/values-it/strings.xml
@@ -164,6 +164,7 @@
     <string name="Snabble.Payment.SEPA.title">Addebito diretto SEPA</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Valid IBAN</string>
     <string name="Snabble.Payment.success">Grazie per il tuo acquisto</string>
+    <string name="Snabble.Payment.transferCart">Transfer shopping cart</string>
     <string name="Snabble.Payment.Twint.error">Si è verificato un errore nell’elaborazione del tuo account TWINT</string>
     <string name="Snabble.Payment.usableAt">Utilizzabile presso: %s</string>
     <string name="Snabble.Payment.waiting">Attendi una conferma</string>

--- a/ui/src/main/res/values-sk/strings.xml
+++ b/ui/src/main/res/values-sk/strings.xml
@@ -168,6 +168,7 @@
     <string name="Snabble.Payment.SEPA.title">SEPA inkaso</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Platný IBAN</string>
     <string name="Snabble.Payment.success">Ďakujeme za tvoj nákup</string>
+    <string name="Snabble.Payment.transferCart">Prenos nákupného koša</string>
     <string name="Snabble.Payment.Twint.error">Pri spracovaní tvojho účtu TWINT sa vyskytla chyba</string>
     <string name="Snabble.Payment.usableAt">Použiteľné tu: %s</string>
     <string name="Snabble.Payment.waiting">Čakanie na potvrdenie</string>
@@ -201,13 +202,13 @@
     <string name="Snabble.PaymentStatus.Payment.title">Platba</string>
     <string name="Snabble.PaymentStatus.Payment.tryAgain">Skúsiť znovu</string>
     <!-- Button to submit the feedback on the checkout screen after a successful checkout. -->
-    <string name="Snabble.PaymentStatus.Rating.send">Odoslať</string>
+    <string name="Snabble.PaymentStatus.Rating.send">Odoslať spätnú väzbu</string>
     <string name="Snabble.PaymentStatus.Rating.title">Čo sa ti nepáčilo?</string>
     <string name="Snabble.PaymentStatus.Rating.title2">Čo by sme mohli vylepšiť?</string>
     <!-- Placeholder text in the input text field on the checkout screen after a successful checkout. -->
-    <string name="Snabble.PaymentStatus.Ratings.feedbackPlaceholder">Feel free to give us more feedback (optional)</string>
+    <string name="Snabble.PaymentStatus.Ratings.feedbackPlaceholder">Neváhaj nám poskytnúť ďalšiu spätnú väzbu (nepovinné)</string>
     <string name="Snabble.PaymentStatus.Ratings.thanks">Ďakujem!</string>
-    <string name="Snabble.PaymentStatus.Ratings.thanksForFeedback">Thanks for your feedback!</string>
+    <string name="Snabble.PaymentStatus.Ratings.thanksForFeedback">Ďakujem za tvoju spätnú väzbu!</string>
     <string name="Snabble.PaymentStatus.Ratings.title">Páčilo sa ti nakupovanie?</string>
     <string name="Snabble.PaymentStatus.Receipt.title">Pokladničný blok</string>
     <string name="Snabble.PaymentStatus.step1">Lokalizácia v oblasti pokladní</string>

--- a/ui/src/main/res/values/attrs.xml
+++ b/ui/src/main/res/values/attrs.xml
@@ -8,4 +8,6 @@
     </declare-styleable>
 
     <attr name="snabbleToolbarStyle" format="reference" />
+
+    <bool name="showCheckoutToolbar">false</bool>
 </resources>

--- a/ui/src/main/res/values/attrs.xml
+++ b/ui/src/main/res/values/attrs.xml
@@ -9,5 +9,5 @@
 
     <attr name="snabbleToolbarStyle" format="reference" />
 
-    <bool name="showCheckoutToolbar">false</bool>
+    <bool name="showToolbarInCheckout">false</bool>
 </resources>

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="snabble_info_color_positive">#009000</color>
     <color name="snabble_info_text_color_positive">#FFFFFF</color>
     <color name="text_input">#DDDDDD</color>
+    <color name="toolbar"/>
 </resources>

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -6,6 +6,5 @@
     <color name="snabble_info_text_color_warning">#000000</color>
     <color name="snabble_info_color_positive">#009000</color>
     <color name="snabble_info_text_color_positive">#FFFFFF</color>
-    <color name="text_input">#DDDDDD</color>
-    <color name="toolbar"/>
+    <color name="snabble_toolbar"/>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="Snabble.Payment.SEPA.title">SEPA direct debit</string>
     <string name="Snabble.Payment.SEPA.validIBAN">Valid IBAN</string>
     <string name="Snabble.Payment.success">Thank you for shopping</string>
+    <string name="Snabble.Payment.transferCart">Transfer shopping cart</string>
     <string name="Snabble.Payment.Twint.error">There was an error processing your TWINT account</string>
     <string name="Snabble.Payment.usableAt">Usable at: %s</string>
     <string name="Snabble.Payment.waiting">Waiting for confirmation</string>


### PR DESCRIPTION
To add a toolbar and to change the statusbar color accordingly a toolbar layout is added to the checkout activity. If a specific bool is set the status bar adjust its color and the gatekeeper contains a matching toolbar.

### How to test?
* Launch the app on this branch without changing anything. No changes should be shown.
* Then:
  1. override the bool 'showCheckoutToolbar' to true
  1. set a color via the color toolbar
  1. launch the application and checkout via terminal
  ->  Toolbar and statusbar should be adjusted now.