### PR TITLE
Fix payment method crash

### DIFF
--- a/core/src/main/java/io/snabble/sdk/PaymentMethodDescriptor.kt
+++ b/core/src/main/java/io/snabble/sdk/PaymentMethodDescriptor.kt
@@ -27,8 +27,8 @@ data class PaymentMethodDescriptor(
      * Convert this descriptor to the SDK [PaymentMethod]
      * Returns a list of PaymentMethods
      */
-    val paymentMethod: PaymentMethod
-        get() = PaymentMethod.fromIdAndOrigin(id, acceptedOriginTypes ?: emptyList())!!
+    val paymentMethod: PaymentMethod?
+        get() = PaymentMethod.fromIdAndOrigin(id, acceptedOriginTypes ?: emptyList())
 }
 
 /**

--- a/core/src/main/java/io/snabble/sdk/Project.kt
+++ b/core/src/main/java/io/snabble/sdk/Project.kt
@@ -508,7 +508,7 @@ class Project internal constructor(jsonObject: JsonObject) {
         assets = Assets(this)
 
         googlePayHelper = paymentMethodDescriptors
-            .map { it.paymentMethod }.mapNotNull { it }
+            .mapNotNull { it.paymentMethod }
             .firstOrNull { it == PaymentMethod.GOOGLE_PAY }
             ?.let {
                 GooglePayHelper(this, Snabble.application)
@@ -524,7 +524,7 @@ class Project internal constructor(jsonObject: JsonObject) {
     }
 
     var googlePayHelper = paymentMethodDescriptors
-        .map { it.paymentMethod }.mapNotNull { it }
+        .mapNotNull { it.paymentMethod }
         .firstOrNull { it == PaymentMethod.GOOGLE_PAY }
         ?.let {
             GooglePayHelper(this, Snabble.application)
@@ -575,7 +575,7 @@ class Project internal constructor(jsonObject: JsonObject) {
      * List of payment methods that should be available to the user
      */
     val availablePaymentMethods
-        get() = paymentMethodDescriptors.map { it.paymentMethod }.mapNotNull { it }
+        get() = paymentMethodDescriptors.mapNotNull { it.paymentMethod }
 
     /**
      * The code template that should be used, when no code template is specified by a scannable code

--- a/core/src/main/java/io/snabble/sdk/Project.kt
+++ b/core/src/main/java/io/snabble/sdk/Project.kt
@@ -508,7 +508,7 @@ class Project internal constructor(jsonObject: JsonObject) {
         assets = Assets(this)
 
         googlePayHelper = paymentMethodDescriptors
-            .map { it.paymentMethod }
+            .map { it.paymentMethod }.mapNotNull { it }
             .firstOrNull { it == PaymentMethod.GOOGLE_PAY }
             ?.let {
                 GooglePayHelper(this, Snabble.application)
@@ -524,7 +524,7 @@ class Project internal constructor(jsonObject: JsonObject) {
     }
 
     var googlePayHelper = paymentMethodDescriptors
-        .map { it.paymentMethod }
+        .map { it.paymentMethod }.mapNotNull { it }
         .firstOrNull { it == PaymentMethod.GOOGLE_PAY }
         ?.let {
             GooglePayHelper(this, Snabble.application)
@@ -575,7 +575,7 @@ class Project internal constructor(jsonObject: JsonObject) {
      * List of payment methods that should be available to the user
      */
     val availablePaymentMethods
-        get() = paymentMethodDescriptors.map { it.paymentMethod }
+        get() = paymentMethodDescriptors.map { it.paymentMethod }.mapNotNull { it }
 
     /**
      * The code template that should be used, when no code template is specified by a scannable code

--- a/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
@@ -220,7 +220,7 @@ class Checkout @JvmOverloads constructor(
 
     private val fallbackPaymentMethod: PaymentMethod?
         get() = project.paymentMethodDescriptors
-            .map { it.paymentMethod }
+            .map { it.paymentMethod }.mapNotNull { it }
             .firstOrNull { it.isOfflineMethod }
 
     /**

--- a/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
@@ -220,7 +220,7 @@ class Checkout @JvmOverloads constructor(
 
     private val fallbackPaymentMethod: PaymentMethod?
         get() = project.paymentMethodDescriptors
-            .map { it.paymentMethod }.mapNotNull { it }
+            .mapNotNull { it.paymentMethod }
             .firstOrNull { it.isOfflineMethod }
 
     /**

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -283,7 +283,7 @@ open class CheckoutBar @JvmOverloads constructor(
             } else {
                 val hasPaymentMethodThatRequiresCredentials =
                     project.paymentMethodDescriptors.any { descriptor ->
-                        descriptor.paymentMethod.isRequiringCredentials
+                        descriptor.paymentMethod?.isRequiringCredentials == true
                     }
                 if (hasPaymentMethodThatRequiresCredentials) {
                     val activity = UIUtils.getHostActivity(context)


### PR DESCRIPTION
### What's new?

On receiving a paymentMethodDescriptor not matching any paymentMethodId the app crashes since the method `fromIdAndOrigin` returns null but the paymentMethod is marked as not null. To fix this the paymentMethod can now be null