### PR TITLE
Solve ProgressDialog deprecation

### DIFF
--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -1,6 +1,5 @@
 package io.snabble.sdk.ui.cart
 
-import android.app.ProgressDialog
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.DialogInterface
@@ -150,7 +149,6 @@ open class CheckoutBar @JvmOverloads constructor(
         update()
 
         progressDialog = DelayedProgressDialog(context)
-        progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER)
         progressDialog.setMessage(context.getString(R.string.Snabble_pleaseWait))
         progressDialog.setCanceledOnTouchOutside(false)
         progressDialog.setCancelable(false)

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/AgeVerificationInputView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/AgeVerificationInputView.java
@@ -54,7 +54,6 @@ public class AgeVerificationInputView extends FrameLayout {
         setFocusableInTouchMode(true);
 
         DelayedProgressDialog progressDialog = new DelayedProgressDialog(getContext());
-        progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
         progressDialog.setMessage(getContext().getString(R.string.Snabble_pleaseWait));
         progressDialog.setCanceledOnTouchOutside(false);
         progressDialog.setCancelable(false);

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/ProductResolver.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/ProductResolver.kt
@@ -615,7 +615,6 @@ class ProductResolver private constructor(private val context: Context, private 
 
     init {
         progressDialog = DelayedProgressDialog(context)
-        progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER)
         progressDialog.setMessage(context.getString(R.string.Snabble_loadingProductInformation))
         progressDialog.setCanceledOnTouchOutside(false)
         progressDialog.setCancelable(false)

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -5,7 +5,6 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
@@ -30,9 +29,6 @@ import androidx.core.util.Pair;
 import java.util.List;
 
 import io.snabble.sdk.BarcodeFormat;
-import io.snabble.sdk.coupons.Coupon;
-import io.snabble.sdk.coupons.CouponCode;
-import io.snabble.sdk.coupons.CouponType;
 import io.snabble.sdk.PriceFormatter;
 import io.snabble.sdk.Product;
 import io.snabble.sdk.ProductDatabase;
@@ -42,6 +38,9 @@ import io.snabble.sdk.ShoppingCart;
 import io.snabble.sdk.Snabble;
 import io.snabble.sdk.ViolationNotification;
 import io.snabble.sdk.codes.ScannedCode;
+import io.snabble.sdk.coupons.Coupon;
+import io.snabble.sdk.coupons.CouponCode;
+import io.snabble.sdk.coupons.CouponType;
 import io.snabble.sdk.ui.R;
 import io.snabble.sdk.ui.SnabbleUI;
 import io.snabble.sdk.ui.checkout.ViolationNotificationUtils;
@@ -140,7 +139,6 @@ public class SelfScanningView extends FrameLayout {
         }
 
         progressDialog = new DelayedProgressDialog(getContext());
-        progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
         progressDialog.setMessage(getContext().getString(R.string.Snabble_loadingProductInformation));
         progressDialog.setCanceledOnTouchOutside(false);
         progressDialog.setCancelable(false);

--- a/ui/src/main/java/io/snabble/sdk/ui/utils/DelayedProgressDialog.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/utils/DelayedProgressDialog.java
@@ -1,6 +1,5 @@
 package io.snabble.sdk.ui.utils;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;

--- a/ui/src/main/java/io/snabble/sdk/ui/utils/ProgressDialog.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/utils/ProgressDialog.kt
@@ -1,0 +1,60 @@
+package io.snabble.sdk.ui.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import io.snabble.sdk.ui.R
+
+open class ProgressDialog(context: Context) : AlertDialog(context) {
+
+    private var indeterminate: Boolean = true
+    private var message: CharSequence? = null
+
+    private var messageView: TextView? = null
+    private var progressBar: ProgressBar? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val view: View = inflateView(context)
+            .also(::bindView)
+        setView(view)
+
+        if (message != null) setMessage(message)
+
+        setIndeterminate(indeterminate)
+
+        super.onCreate(savedInstanceState)
+    }
+
+    @SuppressLint("InflateParams")
+    private fun inflateView(context: Context): View =
+        LayoutInflater.from(context).inflate(R.layout.snabble_progress_dialog, null)
+
+    private fun bindView(view: View) {
+        progressBar = view.findViewById(android.R.id.progress) as? ProgressBar
+        messageView = view.findViewById(android.R.id.message) as? TextView
+    }
+
+    private fun setIndeterminate(indeterminate: Boolean) {
+        val progressBar = progressBar
+
+        if (progressBar != null) {
+            progressBar.isIndeterminate = indeterminate
+        } else {
+            this.indeterminate = indeterminate
+        }
+    }
+
+    override fun setMessage(message: CharSequence?) {
+        val messageView = messageView
+        if (messageView != null) {
+            messageView.text = message
+        } else {
+            this.message = message
+        }
+    }
+}

--- a/ui/src/main/res/layout/snabble_progress_dialog.xml
+++ b/ui/src/main/res/layout/snabble_progress_dialog.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/* //device/apps/common/res/layout/alert_dialog.xml
+**
+** Copyright 2006, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <LinearLayout
+        android:id="@+id/body"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:paddingStart="8dip"
+        android:paddingTop="10dip"
+        android:paddingEnd="8dip"
+        android:paddingBottom="10dip">
+
+        <ProgressBar
+            android:id="@android:id/progress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="12dip"
+            android:max="10000" />
+
+        <TextView
+            android:id="@android:id/message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textAppearance="?attr/textAppearanceBodyMedium" />
+    </LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
Created a new self maintained ProgressDialog to deal w/ the deprecation.
The view should be very similar to the previous one.

### How to test?

* Apply the following changes:
```
diff --git a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
index af57b6877..bd75d8970 100644
--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -159,8 +159,9 @@ open class CheckoutBar @JvmOverloads constructor(
             }
             false
         })
+        progressDialog.show()
 
-        project.checkout.state.observeView(this, ::onStateChanged)
+//        project.checkout.state.observeView(this, ::onStateChanged)
     }
 
     private fun handleButtonClick() {
```
* Install the `kotlint-sample` app
* Check-in a store
* Search for product and it to the basket
* Add a payment method
* Start the checkout
* A ProgressDialog should appear as expected ✅ 
* Switch between light- and dark-mode, the ProgressDialog adjusts accordingly ✅ 