### PR TITLE
Update onActivityResult deprecation info for Google Pay integration

### DIFF
--- a/core/src/main/java/io/snabble/sdk/googlepay/GooglePayHelperActivity.kt
+++ b/core/src/main/java/io/snabble/sdk/googlepay/GooglePayHelperActivity.kt
@@ -2,7 +2,6 @@ package io.snabble.sdk.googlepay
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.gms.wallet.AutoResolveHelper
 import io.snabble.sdk.Snabble
@@ -29,6 +28,10 @@ class GooglePayHelperActivity : AppCompatActivity() {
         }
     }
 
+    // Deprecation is ignored until an updated integration guide of Google Pay has been published,
+    // or another solution can be found:
+    // https://developers.google.com/pay/api/android/guides/tutorial#paymentdata
+    @Suppress("OVERRIDE_DEPRECATION")
     public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {


### PR DESCRIPTION
The onActivityResult deprecation cannot be resolved w/o further information from Google how to integrate Google Pay.
To be able to solve this deprecation the call in question is _AutoResolveHelper::resolveTask_ that relies on the deprecated `onActivityResult` implementation.

**_TL;DR: Won't fix_**