### PR TITLE
Add string localization for purchases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://datatrans.jfrog.io/ui/native/mobile-sdk")
+        maven(url = "https://datatrans.jfrog.io/artifactory/mobile-sdk/")
         maven(url = "https://jitpack.io")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://weareplanet.jfrog.io/artifactory/mobile-sdk/")
+        maven(url = "https://datatrans.jfrog.io/ui/native/mobile-sdk")
         maven(url = "https://jitpack.io")
     }
 

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -76,6 +77,7 @@ fun Purchases(
     purchaseList: List<Purchase>,
     onAction: OnDynamicAction,
 ) {
+    val isSinglePurchase = purchaseList.size == 1
     ConstraintLayout(
         modifier = Modifier
             .fillMaxWidth()
@@ -83,7 +85,8 @@ fun Purchases(
     ) {
         val (title, more, purchases) = createRefs()
         Text(
-            text = "Previous purchases",
+            text = if (isSinglePurchase) stringResource(id = R.string.Snabble_DynamicView_lastPurchase) else
+                stringResource(id = R.string.Snabble_DynamicView_lastPurchases),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = 1,
@@ -117,7 +120,7 @@ fun Purchases(
                 }
         ) {
             Text(
-                text = "More",
+                text = stringResource(id = R.string.Snabble_DynamicView_LastPurchases_all),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.inversePrimary,
                 textAlign = TextAlign.Center,

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
@@ -101,10 +101,7 @@ fun Purchases(
             modifier = Modifier
                 .padding(PaddingValues(horizontal = model.padding.start.dp + MaterialTheme.padding.small))
                 .constrainAs(title) {
-                    start.linkTo(parent.start)
-                    end.linkTo(more.start)
-                    top.linkTo(parent.top)
-                    bottom.linkTo(purchases.top)
+                    linkTo(start = parent.start, top = parent.top, end = more.start, bottom = purchases.top)
                     width = Dimension.fillToConstraints
                 }
         )

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
@@ -109,10 +109,7 @@ fun Purchases(
             contentAlignment = Alignment.Center,
             modifier = Modifier
                 .constrainAs(more) {
-                    start.linkTo(title.end)
-                    end.linkTo(parent.end)
-                    top.linkTo(title.top)
-                    bottom.linkTo(title.bottom)
+                    linkTo(start = title.end, top = title.top, end = parent.end, bottom = title.bottom)
                     height = Dimension.fillToConstraints
                 }
                 .padding(PaddingValues(horizontal = model.padding.start.dp + MaterialTheme.padding.small))

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -78,7 +79,7 @@ fun Purchases(
     purchaseList: List<Purchase>,
     onAction: OnDynamicAction,
 ) {
-    val isSinglePurchase = remember(key1 = purchaseList.size == 1) { mutableStateOf(purchaseList.size == 1) }
+    val isSinglePurchase: Boolean by remember(key1 = purchaseList.size == 1) { mutableStateOf(purchaseList.size == 1) }
 
     ConstraintLayout(
         modifier = Modifier
@@ -86,9 +87,13 @@ fun Purchases(
             .padding(bottom = model.padding.bottom.dp)
     ) {
         val (title, more, purchases) = createRefs()
+        val lastPurchasesTitleStringRes = if (isSinglePurchase) {
+            R.string.Snabble_DynamicView_lastPurchase
+        } else {
+            R.string.Snabble_DynamicView_lastPurchases
+        }
         Text(
-            text = if (isSinglePurchase.value) stringResource(id = R.string.Snabble_DynamicView_lastPurchase) else
-                stringResource(id = R.string.Snabble_DynamicView_lastPurchases),
+            text = stringResource(id = lastPurchasesTitleStringRes),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = 1,
@@ -181,7 +186,12 @@ private fun PurchaseDetail(
                 .fillMaxWidth()
                 .padding(PaddingValues(MaterialTheme.padding.medium))
         ) {
-            val (icon, amount, title, time) = createRefs()
+            val (
+                icon,
+                amount,
+                title,
+                time
+            ) = createRefs()
             Image(
                 painter = painterResource(id = R.drawable.ic_snabble),
                 contentDescription = "",

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/ui/PurchaseWidget.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -77,7 +78,8 @@ fun Purchases(
     purchaseList: List<Purchase>,
     onAction: OnDynamicAction,
 ) {
-    val isSinglePurchase = purchaseList.size == 1
+    val isSinglePurchase = remember(key1 = purchaseList.size == 1) { mutableStateOf(purchaseList.size == 1) }
+
     ConstraintLayout(
         modifier = Modifier
             .fillMaxWidth()
@@ -85,7 +87,7 @@ fun Purchases(
     ) {
         val (title, more, purchases) = createRefs()
         Text(
-            text = if (isSinglePurchase) stringResource(id = R.string.Snabble_DynamicView_lastPurchase) else
+            text = if (isSinglePurchase.value) stringResource(id = R.string.Snabble_DynamicView_lastPurchase) else
                 stringResource(id = R.string.Snabble_DynamicView_lastPurchases),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
@@ -94,15 +96,18 @@ fun Purchases(
             modifier = Modifier
                 .padding(PaddingValues(horizontal = model.padding.start.dp + MaterialTheme.padding.small))
                 .constrainAs(title) {
-                    linkTo(start = parent.start, end = more.start, bias = 0f)
+                    start.linkTo(parent.start)
+                    end.linkTo(more.start)
                     top.linkTo(parent.top)
-                    width = Dimension.preferredWrapContent
+                    bottom.linkTo(purchases.top)
+                    width = Dimension.fillToConstraints
                 }
         )
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
                 .constrainAs(more) {
+                    start.linkTo(title.end)
                     end.linkTo(parent.end)
                     top.linkTo(title.top)
                     bottom.linkTo(title.bottom)


### PR DESCRIPTION
### What's new?

Updated Strings to add missing translations. Also fix UI bug due to missing recomposition.

### How to test?

* Purchase sometings vie the demo store
* Switch to home (should display single purchase headline)
* Purchase something again 
* Switch to home (should display multi purchase headline)