### PR TITLE
Attempt to fix processing of old, unrelated checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+* core: Attempt to fix bug where old checkout processes has been processed
+  * The saved checkout is only used if it's related to the current cart
 
 ## [0.71.2]
 ### Added

--- a/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
@@ -26,7 +26,11 @@ class Checkout @JvmOverloads constructor(
     }
 
     private var persistentState: PersistentState =
-        PersistentState.restore(File(project.internalStorageDirectory, "checkout.json"))
+        PersistentState.restore(
+            file = File(project.internalStorageDirectory, "checkout.json"),
+            cartId = shoppingCart.id,
+            projectId = project.id
+        )
 
     /** The current checkout process response from the backend **/
     var checkoutProcess

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "33"
 targetSdk = "32"
 minSdk = "21"
-gradlePlugin = "8.0.2"
+gradlePlugin = "8.1.1"
 desugarVersion = "1.1.5"
 okhttpVersion = "4.10.0"
 # @pin always, manually updated to ensure overall dependency support


### PR DESCRIPTION
In the _PersistentState_ a checkout process is serialized/deserialized if it's existing, not matter what data it holds. The shopping cart id has been added to that state and on restore it's been checked against the current id of the shopping cart. If it doesn't match an empty _PersistentState_ will be returned instead of an probably old or "invalid" one.

### How to test?

* The `CheckoutTest.kt` tests are still running, especially the test `testCheckoutKeepsStateOnPersistence`.
* Currently, it is unknown when the restored checkout processed is being executed.


### Definition of Done

- [x] Changelog gepflegt
- [x] Selbst greviewed _(aka [Self-Reviews (eng)](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/))_

- App Tests
  - [x] Environments beachtet _(Production/Staging)_

- Testing
  - [x] Tests lokal laufen gelassen
