### PR TITLE
Add support for API levels before 26 (Oreo) to move files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Changed 
 ### Removed
 ### Fixed
+
+## [0.71.5]
+### Fixed
 * Fix crash caused by org.apache.commons.io.FileUtils.moveFile w/ API level below 26 (Android Oreo)
 
 ## [0.71.4]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed 
 ### Removed
 ### Fixed
+* Fix crash caused by org.apache.commons.io.FileUtils.moveFile w/ API level below 26 (Android Oreo)
 
 ## [0.71.4]
 ### Added


### PR DESCRIPTION
Added a self-written copy mechanism because the used one doesn't work anymore on Android API levels below 26.

### How to test?
Install an app integrating this branch on an device w/ API level below 26 and check that it won't crash on start.
* Check that the logging is the same as for device w/ API level >= 26 _(tag is `StringDownloader`)_

### Definition of Done
- [x] Changelog gepflegt
- [x] Selbst greviewed _(aka [Self-Reviews (eng)](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/))_

#### App Tests
  * [x] Edge-Cases getestet
  * [x] Android API Levels wurden berücksichtigt _(minSdk?)_