### PR TITLE
Fix npe caused by required project in the PaymentStatusView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
     * The UI event for paydirekt changed from SHOW_PAYDIREKT_INPUT to SHOW_GIROPAY_INPUT
 * ### Fixed
 * ui: Fixed crash caused by missing project id when calling the PaydirektInputFragment via the PaymentInputViewHelper
+* ui: Fixed crash caused by npe in the PaymentStatusView
 
 ## [0.71.8]
 ### Changed


### PR DESCRIPTION
### What's new?

Fixed crash of the checkout activity caused of an npe in the payment status view if the user opens the app and is not checked in anymore.

APPS-1261

### How to test?

- Apply this patch on the main branch :

```
index c9d00d905..3dcd483e3 100644
--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusFragment.kt
@@ -1,6 +1,20 @@
 package io.snabble.sdk.ui.checkout
 
+import android.os.Bundle
+import androidx.lifecycle.lifecycleScope
+import io.snabble.sdk.Snabble
 import io.snabble.sdk.ui.BaseFragment
 import io.snabble.sdk.ui.R
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-open class PaymentStatusFragment : BaseFragment(R.layout.snabble_fragment_payment_status)
\ No newline at end of file
+open class PaymentStatusFragment : BaseFragment(R.layout.snabble_fragment_payment_status){
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            delay(4000)
+            Snabble.checkedInProject.value = null
+        }
+    }
+}

```

- Buy something -> after 4 sec the checkout should crash (see logs)
- Apply the same patch on this branch :

Now the logs should show the following log :
`2023-12-18 08:33:57.843 11885-11885 (CheckoutA....java:135) io.snabble.sdk.sample                E  Project not set`

### Definition of Done

- [x] Changelog gepflegt
- [x] Dokumentation gepflegt
- [x] Alle Anforderung des Issues sind erfüllt
- [x] Selbst greviewed _(aka [Self-Reviews (eng)](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/))_
