### PR TITLE
Option to limit payment methods offered to add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+## [0.72.4] 
+### Added
+* core, io: Option to limit payment methods offered to add (#173)
+
 ## [0.72.3]
 ### Fixed
 * core, ui: Bind Giropay to its project (#172)

--- a/core/src/main/java/io/snabble/sdk/PaymentMethod.kt
+++ b/core/src/main/java/io/snabble/sdk/PaymentMethod.kt
@@ -1,5 +1,7 @@
 package io.snabble.sdk
 
+import android.os.Parcel
+import android.os.Parcelable
 import androidx.annotation.Nullable
 import com.google.gson.annotations.SerializedName
 
@@ -31,7 +33,7 @@ enum class PaymentMethod(
      * Declares if the payment method can only be aborted with a confirmation by the backend
      */
     val needsAbortConfirmation: Boolean,
-) {
+) : Parcelable {
 
     @SerializedName("qrCodePOS")
     QRCODE_POS(
@@ -168,7 +170,17 @@ enum class PaymentMethod(
         needsAbortConfirmation = true
     );
 
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = dest.writeInt(ordinal)
+
     companion object {
+
+        @JvmField
+        val CREATOR = object : Parcelable.Creator<PaymentMethod> {
+            override fun createFromParcel(parcel: Parcel) = PaymentMethod.values()[parcel.readInt()]
+            override fun newArray(size: Int) = arrayOfNulls<PaymentMethod>(size)
+        }
 
         /**
          * Converts a payment method from its string representation.

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/SelectPaymentMethodFragment.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/SelectPaymentMethodFragment.java
@@ -243,7 +243,7 @@ public class SelectPaymentMethodFragment extends BottomSheetDialogFragment {
         if (parcels == null) return null;
 
         final List<T> list = new ArrayList<>(parcels.length);
-        for (Parcelable parcel : parcels) {
+        for (final Parcelable parcel : parcels) {
             if (parcel.getClass() == clazz) {
                 list.add(((T) parcel));
             }

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/SelectPaymentMethodFragment.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/SelectPaymentMethodFragment.java
@@ -1,6 +1,7 @@
 package io.snabble.sdk.ui.payment;
 
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.snabble.sdk.PaymentMethod;
 import io.snabble.sdk.Project;
@@ -27,10 +29,14 @@ import io.snabble.sdk.ui.utils.OneShotClickListener;
 
 public class SelectPaymentMethodFragment extends BottomSheetDialogFragment {
     public static final String ARG_PROJECT_ID = "projectId";
+    public static final String ARG_SUPPORTED_METHODS = "supportedMethods";
 
     private List<Entry> entries;
     private Set<PaymentMethod> paymentMethods;
     private String projectId;
+
+    @Nullable
+    private List<PaymentMethod> supportedMethods;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -39,6 +45,7 @@ public class SelectPaymentMethodFragment extends BottomSheetDialogFragment {
         Bundle args = getArguments();
         if (args != null) {
             projectId = args.getString(ARG_PROJECT_ID, null);
+            supportedMethods = convertToList(args.getParcelableArray(ARG_SUPPORTED_METHODS), PaymentMethod.class);
         }
     }
 
@@ -51,7 +58,11 @@ public class SelectPaymentMethodFragment extends BottomSheetDialogFragment {
         Set<PaymentMethod> availablePaymentMethods = new HashSet<>();
         for (Project project : Snabble.getInstance().getProjects()) {
             if (project.getId().equals(projectId)) {
-                availablePaymentMethods.addAll(project.getAvailablePaymentMethods());
+                final List<PaymentMethod> methods = project.getAvailablePaymentMethods()
+                        .stream()
+                        .filter(this::isSupportedMethod)
+                        .collect(Collectors.toList());
+                availablePaymentMethods.addAll(methods);
             }
         }
 
@@ -188,6 +199,13 @@ public class SelectPaymentMethodFragment extends BottomSheetDialogFragment {
         return v;
     }
 
+    private boolean isSupportedMethod(@NonNull final PaymentMethod method) {
+        if (supportedMethods != null) {
+            return supportedMethods.contains(method);
+        }
+        return true;
+    }
+
     private String getUsableAtText(PaymentMethod... paymentMethods) {
         List<Project> projects = Snabble.getInstance().getProjects();
         if (projects.size() == 1) {
@@ -217,6 +235,20 @@ public class SelectPaymentMethodFragment extends BottomSheetDialogFragment {
         }
 
         return getResources().getString(R.string.Snabble_Payment_usableAt, sb.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private <T> List<T> convertToList(final Parcelable[] parcels, final Class<T> clazz) {
+        if (parcels == null) return null;
+
+        final List<T> list = new ArrayList<>(parcels.length);
+        for (Parcelable parcel : parcels) {
+            if (parcel.getClass() == clazz) {
+                list.add(((T) parcel));
+            }
+        }
+        return list;
     }
 
     private static class Entry {


### PR DESCRIPTION
An array of supported `PaymentMethods` can now be passed to the _SelectPaymentMethodFragment_ which reduces the methods to be picked from to the array passed at most. If no array is passed all methods configured for the project can be selected.

### How to test?

Integrate this branch in an app and set an array with supported payment methods as bundle argument for the _SelectPaymentMethodFragment_.

### Definition of Done

- [x] Changelog gepflegt
- [x] Dokumentation gepflegt
- [x] Alle Anforderung des Issues sind erfüllt
- [x] Selbst greviewed _(aka [Self-Reviews (eng)](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/))_
- [ ] Review mit Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [x] Minified getestet? _(aka. Release Build)_
- [x] Environements beachtet _(Production/Staging)_
- [x] Unterstützte Sprachen sind getestet
- [x] Light-/Dark-Mode getestet
- [x] Edge-Cases getestet
- [x] Android API Levels wurden berücksichtigt _(minSdk?)_

#### Testing
- ~~Tests geschrieben _(aka Unit-Tests, Integration-Tests)_~~
- [x] Tests lokal laufen gelassen
