### PR TITLE
PaymentSelectionHelper: Fix app crash due to npe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+* ui: Avoid npe caused by `isEmpty()` check on a null shopping cart
 
 ## [0.72.2]
 ### Changed

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/PaymentSelectionHelper.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/PaymentSelectionHelper.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import io.snabble.sdk.PaymentMethod;
 import io.snabble.sdk.Project;
+import io.snabble.sdk.Shop;
 import io.snabble.sdk.ShoppingCart;
 import io.snabble.sdk.Snabble;
 import io.snabble.sdk.checkout.PaymentMethodInfo;
@@ -415,8 +416,9 @@ public class PaymentSelectionHelper {
     }
 
     public boolean shouldShowPayButton() {
-        boolean onlinePaymentAvailable = cart.getAvailablePaymentMethods() != null && !cart.getAvailablePaymentMethods().isEmpty();
-        return cart.getTotalPrice() >= 0 && (onlinePaymentAvailable || selectedEntry.getValue() != null);
+        final ShoppingCart shoppingCart = cart;
+        boolean onlinePaymentAvailable = shoppingCart.getAvailablePaymentMethods() != null && !shoppingCart.getAvailablePaymentMethods().isEmpty();
+        return shoppingCart.getTotalPrice() >= 0 && (onlinePaymentAvailable || selectedEntry.getValue() != null);
     }
 
     public boolean shouldShowGooglePayButton() {

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/PaymentSelectionHelper.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/PaymentSelectionHelper.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import io.snabble.sdk.PaymentMethod;
 import io.snabble.sdk.Project;
-import io.snabble.sdk.Shop;
 import io.snabble.sdk.ShoppingCart;
 import io.snabble.sdk.Snabble;
 import io.snabble.sdk.checkout.PaymentMethodInfo;


### PR DESCRIPTION
### What's new?

Make cart a local var of the method `shouldShowPayButton()` to avoid npe due to a mutable object

### How to test?

I couldn't reproduce the bug. But it should fix it.

For more details see Apps-1365

### Definition of Done

- [x] Changelog gepflegt
