### PR TITLE
ProductResolver: Fix app crash due to IllegalArgumentException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+ui: change project reference in `ProductResolver.kt` to get rid of IllegalArgumentException
 
 ## [0.72.4] 
 ### Added

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/ProductResolver.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/ProductResolver.kt
@@ -1,6 +1,5 @@
 package io.snabble.sdk.ui.scanner
 
-import android.app.ProgressDialog
 import android.content.Context
 import android.content.DialogInterface
 import android.view.KeyEvent
@@ -9,7 +8,6 @@ import io.snabble.sdk.Unit
 import io.snabble.sdk.codes.ScannedCode
 import io.snabble.sdk.codes.gs1.GS1Code
 import io.snabble.sdk.ui.R
-import io.snabble.sdk.ui.SnabbleUI
 import io.snabble.sdk.ui.scanner.ProductResolver.*
 import io.snabble.sdk.ui.telemetry.Telemetry
 import io.snabble.sdk.ui.utils.DelayedProgressDialog
@@ -283,7 +281,7 @@ class ProductResolver private constructor(private val context: Context, private 
 
         if (product != null && scannedCode != null) {
             if (handleProductFlags(product, scannedCode)) {
-                val model = ProductConfirmationDialog.ViewModel(context, SnabbleUI.project, product, scannedCode)
+                val model = ProductConfirmationDialog.ViewModel(context, project, product, scannedCode)
                 productDialogViewModel = model
                 productConfirmationDialog?.show(UIUtils.getHostFragmentActivity(context), model)
             }
@@ -459,9 +457,9 @@ class ProductResolver private constructor(private val context: Context, private 
      * @param context The context for the product resolver
      * @param project The optional project of the product resolver, by default the current project will be used
      */
-    class Builder @JvmOverloads constructor(
+    class Builder(
         context: Context,
-        private val project: Project = requireNotNull(Snabble.checkedInProject.value)
+        private val project: Project
     ) {
         private val productResolver = ProductResolver(context, project)
         private var factory = ProductConfirmationDialog.Factory {

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -179,7 +179,7 @@ public class SelfScanningView extends FrameLayout {
     }
 
     public void lookupAndShowProduct(List<ScannedCode> scannedCodes, BarcodeFormat barcodeFormat) {
-        new ProductResolver.Builder(getContext())
+        new ProductResolver.Builder(getContext(), project)
                 .setCodes(scannedCodes)
                 .setBarcodeFormat(barcodeFormat)
                 .setOnShowListener(this::pauseBarcodeScanner)


### PR DESCRIPTION
### What's new?

Changed project reference to the constructor param to get rid of IllegalArgumentExeption due to requireNotNull(project) reference.

### How to test?

I couldn't reproduce the bug. But it should fix it.

For more details see Apps-1366

### Definition of Done

- [x] Changelog gepflegt

