### PR TITLE
Fix ignore group processing (APPS-1640)

### DIFF
--- a/core/src/main/java/io/snabble/sdk/codes/templates/CodeTemplate.java
+++ b/core/src/main/java/io/snabble/sdk/codes/templates/CodeTemplate.java
@@ -312,9 +312,6 @@ public class CodeTemplate {
             int start = 0;
             for (int i = 0; i < groups.size(); i++) {
                 Group group = groups.get(i);
-                if (i == groups.size() - 1 && group instanceof IgnoreGroup) {
-                    break;
-                }
 
                 if (group instanceof WildcardGroup) {
                     ((WildcardGroup) group).setLength(matchedCode.length() - start);

--- a/core/src/test/java/io/snabble/sdk/CodeTemplateTest.java
+++ b/core/src/test/java/io/snabble/sdk/CodeTemplateTest.java
@@ -106,6 +106,7 @@ public class CodeTemplateTest {
         Assert.assertNotNull(newCodeTemplate("{code:ean14}").match("28000017120605").buildCode());
         Assert.assertNotNull(newCodeTemplate("96{code:ean13}{embed:6}{price:5}{_}").match("960000000000000111111222223").buildCode());
         Assert.assertNotNull(newCodeTemplate("123{_:5}").match("12345678").buildCode());
+        Assert.assertNotNull(newCodeTemplate("9{_:14}").match("912345123451234").buildCode());
 
         Assert.assertEquals("999", newCodeTemplate("123{_:5}{code:3}").match("12345678999").buildCode().getLookupCode());
         Assert.assertEquals("21", newCodeTemplate("{code=21}{_:10}{ec}").match("2134743747736").buildCode().getLookupCode());
@@ -117,6 +118,7 @@ public class CodeTemplateTest {
         Assert.assertNull(newCodeTemplate("{code:ean8}").match("87654320").buildCode());
         Assert.assertNull(newCodeTemplate("96{code:ean13}{embed:6}{price:5}{_}").match("970000000000000111111222223").buildCode());
         Assert.assertNull(newCodeTemplate("123{_:5}").match("55545678").buildCode());
+        Assert.assertNull(newCodeTemplate("9{_:14}").match("9123451234512").buildCode());
     }
 
     @Test


### PR DESCRIPTION
The ignore group processing was faulty and has been fixed now. Code too short are now not being matched by the given template.

See APPS-1640.

### How to test?

* See the test changes and let them run.

### Definition of Done
- [x] Issue ist verlinkt
- ~~Dokumentation gepflegt~~
- ~~Alle Anforderung des Issues sind erfüllt~~
- [x] Selbst greviewed _(aka [Self-Reviews (eng)](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/))_
- [ ] Review mit Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- ~~Minified getestet? _(aka. Release Build)_~~
- ~~Environements beachtet _(Production/Staging)_~~
- ~~Unterstützte Sprachen sind getestet~~
- ~~Light-/Dark-Mode getestet~~
- ~~Edge-Cases getestet~~
- ~~Android API Levels wurden berücksichtigt _(minSdk?)_~~

#### Testing
- [x] Tests geschrieben _(aka Unit-Tests, Integration-Tests)_
- [x] Tests lokal laufen gelassen
