### PR TITLE
Add price modifiers as discount

### DIFF
--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -236,6 +236,7 @@ data class LineItem(
     val weight: Int? = null,
     val weightUnit: String? = null,
     val totalPrice: Int = 0,
+    val listPrice: Int = 0,
     val type: LineItemType? = null,
     val priceModifiers: List<PriceModifier>? = null,
     val redeemed: Boolean = false,

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -236,10 +236,10 @@ data class LineItem(
     val weight: Int? = null,
     val weightUnit: String? = null,
     val totalPrice: Int = 0,
-    val listPrice: Int = 0,
     val type: LineItemType? = null,
     val priceModifiers: List<PriceModifier>? = null,
     val redeemed: Boolean = false,
+    val listPrice: Int = 0,
 )
 
 data class PriceModifier(

--- a/core/src/test/java/io/snabble/sdk/ShoppingCartTest.java
+++ b/core/src/test/java/io/snabble/sdk/ShoppingCartTest.java
@@ -201,7 +201,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 100,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -228,7 +229,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 200,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -254,7 +256,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 154,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -280,7 +283,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 1000,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -307,7 +311,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 500,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -333,7 +338,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 60,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -359,7 +365,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 100,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);
@@ -386,7 +393,8 @@ public class ShoppingCartTest extends SnabbleSdkTest {
                 400,
                 null,
                 null,
-                false
+                false,
+                0
 
         );
         item.setLineItem(lineItem);

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/model/ProductItem.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/model/ProductItem.kt
@@ -12,6 +12,7 @@ internal data class ProductItem(
     val deposit: DepositItem? = null,
     val discountPrice: String? = null,
     val priceText: String? = null,
+    val listPrice: Int = 0,
     val totalPrice: String? = null,
     val isAgeRestricted: Boolean = false,
     val manualDiscountApplied: Boolean = false,
@@ -23,11 +24,11 @@ internal data class ProductItem(
 ) : CartItem {
 
     fun getTotalPrice(): Int {
-        return item.totalPrice + (deposit?.depositPrice ?: 0)
+        return (listPrice * quantity) + (deposit?.depositPrice ?: 0)
     }
 
     fun getDiscountPrice(): Int {
         val discountPrice = discounts.sumOf { it.discountValue }
-        return item.totalPrice + (deposit?.depositPrice ?: 0) + discountPrice
+        return (listPrice * quantity) + (deposit?.depositPrice ?: 0) + discountPrice
     }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/widget/AgeRestrictionIcon.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/widget/AgeRestrictionIcon.kt
@@ -2,8 +2,10 @@ package io.snabble.sdk.ui.cart.shoppingcart.product.widget
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -25,7 +27,8 @@ internal fun AgeRestrictionIcon(isAgeRestricted: Boolean, age: Int) {
             Text(
                 modifier = Modifier.background(Color.Red),
                 text = age.toString(),
-                color = Color.White
+                color = Color.White,
+                style = MaterialTheme.typography.bodyMedium
             )
         }
     }

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/widget/Product.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/widget/Product.kt
@@ -45,7 +45,9 @@ internal fun Product(
             age = cartItem.minimumAge
         )
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-            Row {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 ProductDescription(modifier = Modifier.weight(1f), cartItem)
                 if (cartItem.editable && cartItem.item.product?.type != UserWeighed) {
                     QuantityField(modifier = Modifier, cartItem, onQuantityChanged = {


### PR DESCRIPTION
### What's new?

Price modifiers are now add as a discount and displayed below the referring line-item.

### How to test?
Follows later on.

