### PR TITLE
Fix faulty layout implementation of preauth hint

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,5 @@
 
+APPS-
 
 ### How to test?
 
@@ -9,7 +10,7 @@
 - [ ] All requirements of the issue are fulfilled
 - [ ] Changelog is updated
 - [ ] Documentation is updated
-- [ ] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/))_
+- [ ] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
 - [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_
 
 #### App Tests

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PayoneInputView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PayoneInputView.kt
@@ -11,8 +11,8 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.widget.FrameLayout
 import android.widget.ProgressBar
+import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.Keep
@@ -53,7 +53,7 @@ import java.util.Locale
 import java.util.concurrent.CancellationException
 
 class PayoneInputView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
-    FrameLayout(context, attrs, defStyleAttr), LifecycleEventObserver {
+    RelativeLayout(context, attrs, defStyleAttr), LifecycleEventObserver {
 
     private lateinit var webView: WebView
     private lateinit var progressBar: ProgressBar

--- a/ui/src/main/res/layout/snabble_view_cardinput_creditcard.xml
+++ b/ui/src/main/res/layout/snabble_view_cardinput_creditcard.xml
@@ -1,26 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:parentTag="android.widget.RelativeLayout">
 
     <TextView
         android:id="@+id/threed_secure_hint"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceBodyMedium"
-        android:padding="16dp" />
+        android:padding="16dp"
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
 
     <WebView
         android:id="@+id/web_view"
-        android:layout_below="@+id/threed_secure_hint"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_below="@+id/threed_secure_hint" />
 
     <ProgressBar
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         android:id="@+id/progress"
         style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-7dp"
         android:visibility="gone"
-        android:layout_marginTop="-7dp"/>
+        tools:visibility="visible" />
+
 </merge>


### PR DESCRIPTION
The hint was already there, all the time - just overlayed by the webview due to improper view implementation. That has been fixed.

APPS-1605

### How to test?

* Integrate this branch into an app that's got PAYONE as payment provider and check if the preauth hint occurs, if a preauth is configured.
* Check within the sample app if the hint still works for FiServ, which is configured for the sample project.

### Definition of Done

- [x] Issue is linked
- ~~All requirements of the issue are fulfilled~~
- [x] Changelog is updated
- ~~Documentation is updated~~
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- ~~Minified build has been tested _(aka. Release Build)_~~
- ~~Environments have been taken care of _(Production/Staging)_~~
- ~~Supported languages have been tested~~
- ~~Light-/Dark-Mode has been tested~~
- ~~Edge-Cases have been tested~~
- ~~Android API Levels have been taken care of _(minSdk?)_~~

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
