### PR TITLE
Fix totalPrice calculation

### DIFF
--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -451,7 +451,7 @@ class ShoppingCart(
     val totalPrice: Int
         get() = data.onlineTotalPrice ?: calculateTotalPrice()
 
-    private fun calculateTotalPrice(): Int = data.items.sumOf { it.totalDepositPrice }
+    private fun calculateTotalPrice(): Int = data.items.sumOf { it.totalPrice } + totalDepositPrice
 
     /**
      * Returns the total sum of deposit


### PR DESCRIPTION
During the shopping cart refactoring from #183 the calculateTotalPrice method has been a bit messed up. It now calculates the local price like before in the Java version.