### PR TITLE
Replace items depositText w/ local i18n text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Added
 ### Changed
+* Replace items depositText w/ local i18n text
 ### Removed
 ### Fixed
 

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/widget/description/ProductDescription.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/widget/description/ProductDescription.kt
@@ -7,8 +7,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.snabble.sdk.ui.R
 import io.snabble.sdk.ui.cart.shoppingcart.product.model.ProductItem
 
 @Composable
@@ -34,8 +36,9 @@ internal fun ProductDescription(modifier: Modifier = Modifier, item: ProductItem
             else -> LineItemDescription(item.totalPriceText)
         }
         if (item.deposit != null) {
+            val depositText = stringResource(id = R.string.Snabble_Shoppingcart_deposit)
             Text(
-                text = "${item.priceText} + ${item.deposit.depositPriceText} ${item.deposit.depositText}",
+                text = "${item.priceText} + ${item.deposit.depositPriceText} $depositText",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface
             )


### PR DESCRIPTION
Instead of the item's depositText the name deposit should be displayed. In the corresponding app's language.

APPS-1699

### How to test?

* Integrate these changes in a project where a product w/ the deposit is visible and check it's appearance.

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [ ] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [x] Minified build has been tested _(aka. Release Build)_
- [x] Environments have been taken care of _(Production/Staging)_
- [x] Supported languages have been tested
- [x] Light-/Dark-Mode has been tested
- [x] Edge-Cases have been tested
- [x] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
