### PR TITLE
Handle npe's when loading the shopping cart (APPS-1779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,23 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Added
 ### Changed
-* Replace items depositText w/ local i18n text
 ### Removed
 ### Fixed
+
+## [0.75.7]
+### Fixed
+* Handle npe when loading the shopping cart data and restore from it
+
+## [0.75.6]
+### Changed
+* Replace items depositText w/ local i18n text
+* Switch to only delete a pre auth if a card was successfully saved
+### Fixed
+* Fix SQLiteDatabaseLockedException
+
+## [0.75.5]
+### Fixed
+* Fix npe while calculating the modified price
 
 ## [0.75.4]
 ### Added

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartStorage.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartStorage.kt
@@ -14,6 +14,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
+import java.lang.RuntimeException
 import java.nio.charset.Charset
 import kotlin.time.Duration.Companion.seconds
 

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartStorage.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartStorage.kt
@@ -2,7 +2,6 @@ package io.snabble.sdk.shoppingcart
 
 import android.os.Handler
 import android.os.Looper
-import com.google.gson.JsonSyntaxException
 import io.snabble.sdk.Project
 import io.snabble.sdk.Snabble
 import io.snabble.sdk.shoppingcart.data.listener.SimpleShoppingCartListener
@@ -63,6 +62,7 @@ internal class ShoppingCartStorage(val project: Project) {
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun load() {
         try {
             if (currentFile?.exists() == true) {
@@ -81,11 +81,11 @@ internal class ShoppingCartStorage(val project: Project) {
             }
         } catch (e: IOException) {
             //shopping cart could not be read, create a new one.
-            Logger.e("Could not load shopping list from: " + currentFile?.absolutePath + ", creating a new one.")
+            Logger.e("Could not load shopping list from: ${currentFile?.absolutePath}, creating a new one.")
             project.shoppingCart.initWithData(ShoppingCartData())
-        } catch (e: JsonSyntaxException) {
+        } catch (e: RuntimeException) {
             //shopping cart could not be read, create a new one.
-            Logger.e("Could not parse shopping list due to: ${e.message}")
+            Logger.e("Could not load shopping list from ${currentFile?.absolutePath}:  ${e.message}")
             project.shoppingCart.initWithData(ShoppingCartData())
         }
     }


### PR DESCRIPTION
When loading the shopping cart some exception have not be handled leading to a npe. To handle this we now catch runtime exceptions to handle if the loading fails and create a new empty shopping cart. 
We also only init the shopping cart with data if the data is not null to avoid npe's later on.

APPS-1779

### How to test?


### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [ ] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
