### PR TITLE
Adjust new primary button to keep default states

### DIFF
--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/repository/PurchasesRepository.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/purchase/repository/PurchasesRepository.kt
@@ -41,8 +41,11 @@ internal class PurchasesRepositoryImpl(
         }
     }
 
-    private fun Array<ReceiptInfo>.mapToPurchases(count: Int): List<Purchase> =
-        this.filter { it.pdfUrl != null }
+    private fun Array<ReceiptInfo>.mapToPurchases(count: Int): List<Purchase> {
+        val purchases = filter { it.pdfUrl != null }
+        if (purchases.isEmpty()) return emptyList()
+        return purchases
             .slice(0 until size.coerceAtMost(count))
             .map { it.toPurchase(timeFormatter) }
+    }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
@@ -79,9 +79,11 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
         recyclerView.setItemAnimator(null);
 
         FloatingActionButton fab = findViewById(R.id.fab);
+
         final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
         final int primaryColor = RemoteThemingExtensionsKt.getPrimaryColorForProject(getContext(), currentProject);
         final int onPrimaryColor = RemoteThemingExtensionsKt.getOnPrimaryColorForProject(getContext(), currentProject);
+
         fab.setBackgroundTintList(ColorStateList.valueOf(primaryColor));
         fab.setImageTintList(ColorStateList.valueOf(onPrimaryColor));
 
@@ -116,7 +118,9 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
                             .setCancelable(false)
                             .show();
 
-                    RemoteThemingExtensionsKt.setButtonColorFor(alertDialog, currentProject).show();
+                    RemoteThemingExtensionsKt
+                            .setButtonColorFor(alertDialog, currentProject)
+                            .show();
                 }
             }
         });
@@ -301,7 +305,10 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
                             .setNegativeButton(R.string.Snabble_no, null)
                             .create();
                     final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
-                    RemoteThemingExtensionsKt.setButtonColorFor(alertDialog, currentProject).show();
+
+                    RemoteThemingExtensionsKt
+                            .setButtonColorFor(alertDialog, currentProject)
+                            .show();
 
                     Telemetry.event(Telemetry.Event.PaymentMethodDeleted, e.paymentCredentials.getType());
                 });

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
@@ -6,6 +6,7 @@ import static io.snabble.sdk.payment.PaymentCredentials.Type;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -21,6 +22,8 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +33,7 @@ import io.snabble.sdk.Snabble;
 import io.snabble.sdk.payment.PaymentCredentials;
 import io.snabble.sdk.payment.PaymentCredentialsStore;
 import io.snabble.sdk.ui.R;
+import io.snabble.sdk.ui.remotetheme.RemoteThemingExtensionsKt;
 import io.snabble.sdk.ui.telemetry.Telemetry;
 import io.snabble.sdk.ui.utils.KeyguardUtils;
 import io.snabble.sdk.ui.utils.OneShotClickListener;
@@ -74,7 +78,13 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setItemAnimator(null);
 
-        View fab = findViewById(R.id.fab);
+        FloatingActionButton fab = findViewById(R.id.fab);
+        final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
+        final int primaryColor = RemoteThemingExtensionsKt.getPrimaryColorForProject(getContext(), currentProject);
+        final int onPrimaryColor = RemoteThemingExtensionsKt.getOnPrimaryColorForProject(getContext(), currentProject);
+        fab.setBackgroundTintList(ColorStateList.valueOf(primaryColor));
+        fab.setImageTintList(ColorStateList.valueOf(onPrimaryColor));
+
         fab.setOnClickListener(new OneShotClickListener() {
             @Override
             public void click() {
@@ -100,11 +110,13 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
                         throw new RuntimeException("Host activity must be a Fragment Activity");
                     }
                 } else {
-                    new AlertDialog.Builder(getContext())
+                    final AlertDialog alertDialog = new AlertDialog.Builder(getContext())
                             .setMessage(R.string.Snabble_Keyguard_requireScreenLock)
                             .setPositiveButton(R.string.Snabble_ok, null)
                             .setCancelable(false)
                             .show();
+
+                    RemoteThemingExtensionsKt.setButtonColorFor(alertDialog, currentProject).show();
                 }
             }
         });
@@ -204,7 +216,7 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
                         entries.add(new Entry(pm, R.drawable.snabble_ic_payment_select_tegut, pm.getObfuscatedId()));
                         break;
                     case EXTERNAL_BILLING:
-                        entries.add(new Entry(pm,R.drawable.ic_snabble_external_billing,pm.getObfuscatedId()));
+                        entries.add(new Entry(pm, R.drawable.ic_snabble_external_billing, pm.getObfuscatedId()));
                         break;
                 }
             }
@@ -283,12 +295,13 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
 
             if (e.paymentCredentials != null) {
                 vh.delete.setOnClickListener(view -> {
-                    new AlertDialog.Builder(getContext())
+                    final AlertDialog alertDialog = new AlertDialog.Builder(getContext())
                             .setMessage(R.string.Snabble_Payment_Delete_message)
                             .setPositiveButton(R.string.Snabble_yes, (dialog, which) -> paymentCredentialsStore.remove(e.paymentCredentials))
                             .setNegativeButton(R.string.Snabble_no, null)
-                            .create()
-                            .show();
+                            .create();
+                    final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
+                    RemoteThemingExtensionsKt.setButtonColorFor(alertDialog, currentProject).show();
 
                     Telemetry.event(Telemetry.Event.PaymentMethodDeleted, e.paymentCredentials.getType());
                 });

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentInputViewHelper.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentInputViewHelper.kt
@@ -13,7 +13,7 @@ import io.snabble.sdk.ui.SnabbleUI
 import io.snabble.sdk.ui.payment.creditcard.datatrans.ui.DatatransFragment
 import io.snabble.sdk.ui.payment.creditcard.fiserv.FiservInputView
 import io.snabble.sdk.ui.payment.externalbilling.ExternalBillingFragment.Companion.ARG_PROJECT_ID
-import io.snabble.sdk.ui.remotetheme.getPrimaryColorForProject
+import io.snabble.sdk.ui.remotetheme.setButtonColorFor
 import io.snabble.sdk.ui.utils.KeyguardUtils
 import io.snabble.sdk.ui.utils.UIUtils
 import io.snabble.sdk.utils.Logger
@@ -75,13 +75,11 @@ object PaymentInputViewHelper {
                 .setCancelable(false)
                 .create()
 
-            val primaryColor: Int = context.getPrimaryColorForProject(Snabble.instance.checkedInProject.value)
+            val currentProject = Snabble.instance.checkedInProject.value
 
-            alertDialog.setOnShowListener {
-                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(primaryColor)
-            }
-
-            alertDialog.show()
+            alertDialog
+                .setButtonColorFor(currentProject)
+                .show()
         }
     }
 

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/RemoteThemingExtensions.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/RemoteThemingExtensions.kt
@@ -2,6 +2,7 @@ package io.snabble.sdk.ui.remotetheme
 
 import android.content.Context
 import android.graphics.Color
+import androidx.appcompat.app.AlertDialog
 import io.snabble.sdk.Project
 import io.snabble.sdk.ui.R
 import io.snabble.sdk.utils.getColorByAttribute
@@ -48,4 +49,13 @@ fun Context.isDarkMode(): Boolean {
     val currentNightMode =
         resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK
     return currentNightMode == android.content.res.Configuration.UI_MODE_NIGHT_YES
+}
+
+fun AlertDialog.setButtonColorFor(project: Project?): AlertDialog {
+    val primaryColor = context.getPrimaryColorForProject(project)
+    setOnShowListener {
+        getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(primaryColor);
+        getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(primaryColor);
+    }
+    return this
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
@@ -62,17 +62,16 @@ class SnabblePrimaryButton @JvmOverloads constructor(
         val defaultDisabledTextColor =
             defaultTextColorStateList.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentTextColor)
 
-        val states2 = arrayOf(
+        val states = arrayOf(
             intArrayOf(-android.R.attr.state_enabled),
             intArrayOf(android.R.attr.state_enabled)
         )
 
-        val colors2 = intArrayOf(
+        val colors = intArrayOf(
             defaultDisabledTextColor,
             context.getOnPrimaryColorForProject(project)
         )
 
-        val colorStateList2 = ColorStateList(states2, colors2)
-        setTextColor(colorStateList2)
+        setTextColor(ColorStateList(states, colors))
     }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
@@ -1,10 +1,11 @@
 package io.snabble.sdk.ui.remotetheme
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import com.google.android.material.button.MaterialButton
+import io.snabble.sdk.Project
 import io.snabble.sdk.Snabble
-import io.snabble.sdk.ui.R
 
 /**
  * A default Materialbutton which automatically sets the remote theme colors of the
@@ -13,7 +14,7 @@ import io.snabble.sdk.ui.R
 class SnabblePrimaryButton @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = R.attr.materialButtonStyle,
+    defStyleAttr: Int = 0,
 ) : MaterialButton(context, attrs, defStyleAttr) {
 
     init {
@@ -21,8 +22,68 @@ class SnabblePrimaryButton @JvmOverloads constructor(
     }
 
     private fun setProjectAppTheme() {
+
         val project = Snabble.checkedInProject.value
-        setBackgroundColor(context.getPrimaryColorForProject(project))
-        setTextColor(context.getOnPrimaryColorForProject(project))
+
+        setBackgroundColorFor(project)
+        setTextColorFor(project)
+    }
+
+    private fun setBackgroundColorFor(project: Project?) {
+        // Get the existing ColorStateList for the button's background tint
+        val defaultBackgroundTintList = backgroundTintList
+
+        // Fallback to current background color if there's no existing tint list
+        val currentBackgroundColor = backgroundTintList?.defaultColor ?: currentTextColor
+
+        // Extract the default disabled and pressed colors
+        val defaultDisabledBackgroundColor = defaultBackgroundTintList?.getColorForState(
+            intArrayOf(-android.R.attr.state_enabled),
+            currentBackgroundColor
+        )
+        val defaultPressedBackgroundColor = defaultBackgroundTintList?.getColorForState(
+            intArrayOf(android.R.attr.state_pressed),
+            currentBackgroundColor
+        )
+
+        val states = arrayOf(
+            intArrayOf(-android.R.attr.state_enabled),
+            intArrayOf(android.R.attr.state_pressed),
+            intArrayOf(android.R.attr.state_enabled)
+        )
+
+        val colors = intArrayOf(
+            defaultDisabledBackgroundColor ?: currentBackgroundColor,
+            defaultPressedBackgroundColor ?: currentBackgroundColor,
+            context.getPrimaryColorForProject(project)
+        )
+
+        val colorStateList = ColorStateList(states, colors)
+        backgroundTintList = colorStateList
+    }
+
+    private fun setTextColorFor(project: Project?){
+        val defaultTextColorStateList = textColors
+
+        // Extract the default disabled and pressed colors
+        val defaultDisabledTextColor =
+            defaultTextColorStateList.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentTextColor)
+        val defaultPressedTextColor =
+            defaultTextColorStateList.getColorForState(intArrayOf(android.R.attr.state_pressed), currentTextColor)
+
+        val states2 = arrayOf(
+            intArrayOf(-android.R.attr.state_enabled),
+            intArrayOf(android.R.attr.state_pressed),
+            intArrayOf(android.R.attr.state_enabled)
+        )
+
+        val colors2 = intArrayOf(
+            defaultDisabledTextColor,
+            defaultPressedTextColor,
+            context.getOnPrimaryColorForProject(project)
+        )
+
+        val colorStateList2 = ColorStateList(states2, colors2)
+        setTextColor(colorStateList2)
     }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
@@ -6,10 +6,13 @@ import android.util.AttributeSet
 import com.google.android.material.button.MaterialButton
 import io.snabble.sdk.Project
 import io.snabble.sdk.Snabble
+import io.snabble.sdk.ui.R
 
 /**
  * A default Materialbutton which automatically sets the remote theme colors of the
  * current checked in project.
+ *
+ * To disable this behaviour override the given style and set `usePrimaryColors` to `false`
  */
 class SnabblePrimaryButton @JvmOverloads constructor(
     context: Context,
@@ -18,7 +21,9 @@ class SnabblePrimaryButton @JvmOverloads constructor(
 ) : MaterialButton(context, attrs, defStyleAttr) {
 
     init {
-        setProjectAppTheme()
+        if (useProjectColors(attrs)) {
+            setProjectAppTheme()
+        }
     }
 
     private fun setProjectAppTheme() {
@@ -27,6 +32,21 @@ class SnabblePrimaryButton @JvmOverloads constructor(
 
         setBackgroundColorFor(project)
         setTextColorFor(project)
+    }
+
+    private fun useProjectColors(attrs: AttributeSet?): Boolean {
+        context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.SnabblePrimaryButton,
+            0,
+            0
+        ).apply {
+            return try {
+                getBoolean(R.styleable.SnabblePrimaryButton_usePrimaryColors, true)
+            } finally {
+                recycle()
+            }
+        }
     }
 
     private fun setBackgroundColorFor(project: Project?) {
@@ -55,7 +75,7 @@ class SnabblePrimaryButton @JvmOverloads constructor(
         backgroundTintList = ColorStateList(states, colors)
     }
 
-    private fun setTextColorFor(project: Project?){
+    private fun setTextColorFor(project: Project?) {
         val defaultTextColorStateList = textColors
 
         // Extract the default disabled and pressed colors

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
@@ -41,20 +41,14 @@ class SnabblePrimaryButton @JvmOverloads constructor(
             intArrayOf(-android.R.attr.state_enabled),
             currentBackgroundColor
         )
-        val defaultPressedBackgroundColor = defaultBackgroundTintList?.getColorForState(
-            intArrayOf(android.R.attr.state_pressed),
-            currentBackgroundColor
-        )
 
         val states = arrayOf(
             intArrayOf(-android.R.attr.state_enabled),
-            intArrayOf(android.R.attr.state_pressed),
             intArrayOf(android.R.attr.state_enabled)
         )
 
         val colors = intArrayOf(
             defaultDisabledBackgroundColor ?: currentBackgroundColor,
-            defaultPressedBackgroundColor ?: currentBackgroundColor,
             context.getPrimaryColorForProject(project)
         )
 
@@ -68,18 +62,14 @@ class SnabblePrimaryButton @JvmOverloads constructor(
         // Extract the default disabled and pressed colors
         val defaultDisabledTextColor =
             defaultTextColorStateList.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentTextColor)
-        val defaultPressedTextColor =
-            defaultTextColorStateList.getColorForState(intArrayOf(android.R.attr.state_pressed), currentTextColor)
 
         val states2 = arrayOf(
             intArrayOf(-android.R.attr.state_enabled),
-            intArrayOf(android.R.attr.state_pressed),
             intArrayOf(android.R.attr.state_enabled)
         )
 
         val colors2 = intArrayOf(
             defaultDisabledTextColor,
-            defaultPressedTextColor,
             context.getOnPrimaryColorForProject(project)
         )
 

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabblePrimaryButton.kt
@@ -36,7 +36,7 @@ class SnabblePrimaryButton @JvmOverloads constructor(
         // Fallback to current background color if there's no existing tint list
         val currentBackgroundColor = backgroundTintList?.defaultColor ?: currentTextColor
 
-        // Extract the default disabled and pressed colors
+        // Extract the default disabled color
         val defaultDisabledBackgroundColor = defaultBackgroundTintList?.getColorForState(
             intArrayOf(-android.R.attr.state_enabled),
             currentBackgroundColor
@@ -52,8 +52,7 @@ class SnabblePrimaryButton @JvmOverloads constructor(
             context.getPrimaryColorForProject(project)
         )
 
-        val colorStateList = ColorStateList(states, colors)
-        backgroundTintList = colorStateList
+        backgroundTintList = ColorStateList(states, colors)
     }
 
     private fun setTextColorFor(project: Project?){

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
@@ -17,7 +17,7 @@ import io.snabble.sdk.ui.R
 class SnabbleSecondaryButton @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = R.attr.materialButtonStyle,
+    defStyleAttr: Int = R.attr.buttonStyle,
 ) : MaterialButton(context, attrs, defStyleAttr) {
 
     init {

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
@@ -1,8 +1,10 @@
 package io.snabble.sdk.ui.remotetheme
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import com.google.android.material.button.MaterialButton
+import io.snabble.sdk.Project
 import io.snabble.sdk.Snabble
 import io.snabble.sdk.ui.R
 
@@ -24,6 +26,31 @@ class SnabbleSecondaryButton @JvmOverloads constructor(
 
     private fun setProjectAppTheme() {
         val project = Snabble.checkedInProject.value
-        setTextColor(context.getPrimaryColorForProject(project))
+        setTextColorFor(project)
+    }
+
+    private fun setTextColorFor(project: Project?) {
+        val defaultTextColorStateList = textColors
+
+        // Extract the default disabled and pressed colors
+        val defaultDisabledTextColor =
+            defaultTextColorStateList.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentTextColor)
+        val defaultPressedTextColor =
+            defaultTextColorStateList.getColorForState(intArrayOf(android.R.attr.state_pressed), currentTextColor)
+
+        val states2 = arrayOf(
+            intArrayOf(-android.R.attr.state_enabled),
+            intArrayOf(android.R.attr.state_pressed),
+            intArrayOf(android.R.attr.state_enabled)
+        )
+
+        val colors2 = intArrayOf(
+            defaultDisabledTextColor,
+            defaultPressedTextColor,
+            context.getOnPrimaryColorForProject(project)
+        )
+
+        val colorStateList2 = ColorStateList(states2, colors2)
+        setTextColor(colorStateList2)
     }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
@@ -32,23 +32,22 @@ class SnabbleSecondaryButton @JvmOverloads constructor(
     private fun setTextColorFor(project: Project?) {
         val defaultTextColorStateList = textColors
 
-        // Extract the default disabled and pressed colors
+        // Extract the default disabled color
         val defaultDisabledTextColor = defaultTextColorStateList.getColorForState(
                 intArrayOf(-android.R.attr.state_enabled),
                 currentTextColor
             )
 
-        val states2 = arrayOf(
+        val states = arrayOf(
             intArrayOf(-android.R.attr.state_enabled),
             intArrayOf(android.R.attr.state_enabled)
         )
 
-        val colors2 = intArrayOf(
+        val colors = intArrayOf(
             defaultDisabledTextColor,
             context.getPrimaryColorForProject(project)
         )
 
-        val colorStateList2 = ColorStateList(states2, colors2)
-        setTextColor(colorStateList2)
+        setTextColor(ColorStateList(states, colors))
     }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/remotetheme/SnabbleSecondaryButton.kt
@@ -33,21 +33,19 @@ class SnabbleSecondaryButton @JvmOverloads constructor(
         val defaultTextColorStateList = textColors
 
         // Extract the default disabled and pressed colors
-        val defaultDisabledTextColor =
-            defaultTextColorStateList.getColorForState(intArrayOf(-android.R.attr.state_enabled), currentTextColor)
-        val defaultPressedTextColor =
-            defaultTextColorStateList.getColorForState(intArrayOf(android.R.attr.state_pressed), currentTextColor)
+        val defaultDisabledTextColor = defaultTextColorStateList.getColorForState(
+                intArrayOf(-android.R.attr.state_enabled),
+                currentTextColor
+            )
 
         val states2 = arrayOf(
             intArrayOf(-android.R.attr.state_enabled),
-            intArrayOf(android.R.attr.state_pressed),
             intArrayOf(android.R.attr.state_enabled)
         )
 
         val colors2 = intArrayOf(
             defaultDisabledTextColor,
-            defaultPressedTextColor,
-            context.getOnPrimaryColorForProject(project)
+            context.getPrimaryColorForProject(project)
         )
 
         val colorStateList2 = ColorStateList(states2, colors2)

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -334,17 +334,8 @@ public class SelfScanningView extends FrameLayout {
                     .setOnDismissListener(dialog -> resumeBarcodeScanner())
                     .create();
 
-            final int primaryColor = RemoteThemingExtensionsKt.getPrimaryColorForProject(
-                    getContext(),
-                    Snabble.getInstance().getCheckedInProject().getLatestValue()
-            );
-
-            alertDialog.setOnShowListener(dialog -> {
-                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(primaryColor);
-                alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(primaryColor);
-            });
-
-            alertDialog.show();
+            final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
+            RemoteThemingExtensionsKt.setButtonColorFor(alertDialog,currentProject).show();
 
             input.requestFocus();
 

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -335,7 +335,10 @@ public class SelfScanningView extends FrameLayout {
                     .create();
 
             final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
-            RemoteThemingExtensionsKt.setButtonColorFor(alertDialog,currentProject).show();
+
+            RemoteThemingExtensionsKt
+                    .setButtonColorFor(alertDialog,currentProject)
+                    .show();
 
             input.requestFocus();
 

--- a/ui/src/main/res/layout/snabble_view_checkout_bar.xml
+++ b/ui/src/main/res/layout/snabble_view_checkout_bar.xml
@@ -115,7 +115,7 @@
                 layout="@layout/snabble_buy_with_googlepay_button_no_shadow"/>
         </LinearLayout>
 
-        <com.google.android.material.button.MaterialButton
+        <io.snabble.sdk.ui.remotetheme.SnabblePrimaryButton
             style="@style/Snabble.Widget.MaterialComponents.Button.Passive"
             android:id="@+id/payment_selector_button_big"
             android:layout_width="match_parent"

--- a/ui/src/main/res/values/attrs.xml
+++ b/ui/src/main/res/values/attrs.xml
@@ -7,6 +7,10 @@
         <attr name="animateBarcode" format="boolean" />
     </declare-styleable>
 
+    <declare-styleable name="SnabblePrimaryButton">
+        <attr name="usePrimaryColors" format="boolean" />
+    </declare-styleable>
+
     <attr name="snabbleToolbarStyle" format="reference" />
 
     <bool name="showToolbarInCheckout">false</bool>


### PR DESCRIPTION
Just setting the background color disables the default state colors of the button. This has been adjusted to keep disabled colors. 

Also the code have been cleaned up and some missing changes have been added. 