### PR TITLE
Add feature to pass through payment credentials w/o saving (APPS-1648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+## [0.77.0]
+### Added
+* core/ui: Add a feature to pass payment credentials w/o saving it into storage
+
+## [0.76.0]
+* Maintenance update w/ dependency updates
+
 ## [0.75.8]
 ### Changed
 * ui: Refactor RemoteThemingExtensions

--- a/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsFlow.kt
+++ b/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsFlow.kt
@@ -1,0 +1,32 @@
+@file:JvmName("PaymentCredentialsFlow")
+
+package io.snabble.sdk.payment
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+internal interface MutableCredentialsFlow {
+
+    fun tryEmitCredentials(credentials: PaymentCredentials): Boolean
+}
+
+/**
+ * This flow is emitting payment credentials if adding a payment method has been configured to be added without being
+ * saved.
+ *
+ * Payment method being added the regular way, won't be emitted here.
+ * The [PaymentCredentialsStore.OnPaymentCredentialsAddedListener] is called in that case.
+ */
+object PaymentCredentialsFlow : MutableCredentialsFlow {
+
+    private val _credentialsFlow = MutableStateFlow<PaymentCredentials?>(null)
+
+    /**
+     * Collect this flow to be notified if payment credentials has been created successfully.
+     * If there are no collectors, it will be discarded.
+     */
+    val credentialsFlow: SharedFlow<PaymentCredentials?> = _credentialsFlow.asSharedFlow()
+
+    override fun tryEmitCredentials(credentials: PaymentCredentials): Boolean = _credentialsFlow.tryEmit(credentials)
+}

--- a/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsStore.java
+++ b/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsStore.java
@@ -169,6 +169,10 @@ public class PaymentCredentialsStore {
         notifyChanged();
     }
 
+    public synchronized void justEmitCredentials(final PaymentCredentials credentials) {
+        ((MutableCredentialsFlow) PaymentCredentialsFlow.INSTANCE).tryEmitCredentials(credentials);
+    }
+
     /**
      * Remove and persist payment credentials
      */

--- a/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/devsettings/login/ui/DevSettingsLogin.kt
+++ b/ui-toolkit/src/main/kotlin/io/snabble/sdk/widgets/snabble/devsettings/login/ui/DevSettingsLogin.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
@@ -108,7 +107,6 @@ private fun PasswordField(
     onPasswordChange: (String) -> Unit,
     onAction: () -> Unit,
 ) {
-    @OptIn(ExperimentalMaterial3Api::class)
     OutlinedTextField(
         value = password,
         onValueChange = onPasswordChange,

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentInputViewHelper.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentInputViewHelper.kt
@@ -20,8 +20,14 @@ import io.snabble.sdk.utils.Logger
 
 object PaymentInputViewHelper {
 
+    @JvmOverloads
     @JvmStatic
-    fun openPaymentInputView(context: Context, paymentMethod: PaymentMethod?, projectId: String) {
+    fun openPaymentInputView(
+        context: Context,
+        paymentMethod: PaymentMethod?,
+        projectId: String,
+        saveMethod: Boolean = true
+    ) {
         if (KeyguardUtils.isDeviceSecure()) {
             val project = Snabble.getProjectById(projectId) ?: return
             if (paymentMethod == null) {
@@ -44,11 +50,12 @@ object PaymentInputViewHelper {
                     SnabbleUI.executeAction(context, SnabbleUI.Event.SHOW_DATATRANS_INPUT, args)
                 }
 
-                usePayone -> Payone.registerCard(activity, project, paymentMethod, Snabble.formPrefillData)
+                usePayone -> Payone.registerCard(activity, project, paymentMethod, saveMethod, Snabble.formPrefillData)
 
                 useFiserv -> {
                     args.putString(FiservInputView.ARG_PROJECT_ID, projectId)
                     args.putSerializable(FiservInputView.ARG_PAYMENT_TYPE, paymentMethod.name)
+                    args.putBoolean(FiservInputView.ARG_SAVE_PAYMENT_CREDENTIALS, saveMethod)
                     SnabbleUI.executeAction(context, SnabbleUI.Event.SHOW_FISERV_INPUT, args)
                 }
 

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/Payone.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/Payone.kt
@@ -1,8 +1,8 @@
 package io.snabble.sdk.ui.payment
 
-import android.os.Bundle
 import android.os.Parcelable
 import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
 import com.google.gson.annotations.SerializedName
 import io.snabble.sdk.PaymentMethod
@@ -11,6 +11,11 @@ import io.snabble.sdk.Snabble
 import io.snabble.sdk.payment.data.FormPrefillData
 import io.snabble.sdk.ui.R
 import io.snabble.sdk.ui.SnabbleUI
+import io.snabble.sdk.ui.payment.PayoneInputView.Companion.ARG_FORM_PREFILL_DATA
+import io.snabble.sdk.ui.payment.PayoneInputView.Companion.ARG_PAYMENT_TYPE
+import io.snabble.sdk.ui.payment.PayoneInputView.Companion.ARG_PROJECT_ID
+import io.snabble.sdk.ui.payment.PayoneInputView.Companion.ARG_SAVE_PAYMENT_CREDENTIALS
+import io.snabble.sdk.ui.payment.PayoneInputView.Companion.ARG_TOKEN_DATA
 import io.snabble.sdk.utils.Dispatch
 import io.snabble.sdk.utils.Logger
 import io.snabble.sdk.utils.SimpleJsonCallback
@@ -77,6 +82,7 @@ object Payone {
         activity: FragmentActivity,
         project: Project,
         paymentMethod: PaymentMethod,
+        saveCredentials: Boolean,
         formPrefillData: FormPrefillData?
     ) {
         val descriptor = project.paymentMethodDescriptors.find { it.paymentMethod == paymentMethod }
@@ -108,11 +114,13 @@ object Payone {
         project.okHttpClient.newCall(request)
             .enqueue(object : SimpleJsonCallback<PayoneTokenizationData>(PayoneTokenizationData::class.java), Callback {
                 override fun success(response: PayoneTokenizationData) {
-                    val args = Bundle()
-                    args.putString(PayoneInputView.ARG_PROJECT_ID, project.id)
-                    args.putSerializable(PayoneInputView.ARG_PAYMENT_TYPE, paymentMethod)
-                    args.putParcelable(PayoneInputView.ARG_TOKEN_DATA, response)
-                    args.putParcelable(PayoneInputView.ARG_FORM_PREFILL_DATA, formPrefillData)
+                    val args = bundleOf(
+                        ARG_PROJECT_ID to project.id,
+                        ARG_SAVE_PAYMENT_CREDENTIALS to saveCredentials,
+                        ARG_PAYMENT_TYPE to paymentMethod,
+                        ARG_TOKEN_DATA to response,
+                        ARG_FORM_PREFILL_DATA to formPrefillData
+                    )
                     Dispatch.mainThread {
                         SnabbleUI.executeAction(activity, SnabbleUI.Event.SHOW_PAYONE_INPUT, args)
                     }

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PayoneInputFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PayoneInputFragment.kt
@@ -16,6 +16,7 @@ open class PayoneInputFragment : BaseFragment(
     companion object {
         const val ARG_PROJECT_ID = PayoneInputView.ARG_PROJECT_ID
         const val ARG_PAYMENT_TYPE = PayoneInputView.ARG_PAYMENT_TYPE
+        const val ARG_SAVE_PAYMENT_CREDENTIALS = PayoneInputView.ARG_SAVE_PAYMENT_CREDENTIALS
         const val ARG_TOKEN_DATA = PayoneInputView.ARG_TOKEN_DATA
         const val ARG_FORM_PREFILL_DATA = PayoneInputView.ARG_FORM_PREFILL_DATA
     }
@@ -24,18 +25,20 @@ open class PayoneInputFragment : BaseFragment(
     private lateinit var paymentMethod: PaymentMethod
     private lateinit var tokenizationData: Payone.PayoneTokenizationData
     private var formPrefillData: FormPrefillData? = null
+    private var saveCredentials: Boolean = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         projectId = requireNotNull(arguments?.getString(ARG_PROJECT_ID, null))
         paymentMethod = requireNotNull(arguments?.serializableExtra(ARG_PAYMENT_TYPE) as? PaymentMethod)
+        saveCredentials = arguments?.getBoolean(ARG_SAVE_PAYMENT_CREDENTIALS, true) ?: true
         tokenizationData = requireNotNull(arguments?.parcelableExtra(ARG_TOKEN_DATA))
         formPrefillData = arguments?.parcelableExtra(ARG_FORM_PREFILL_DATA)
     }
 
     override fun onActualViewCreated(view: View, savedInstanceState: Bundle?) {
         view.findViewById<PayoneInputView>(R.id.user_payment_method_view)
-            .load(projectId, paymentMethod, tokenizationData, formPrefillData)
+            .load(projectId, paymentMethod, saveCredentials, tokenizationData, formPrefillData)
     }
 }

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/creditcard/fiserv/FiservInputFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/creditcard/fiserv/FiservInputFragment.kt
@@ -23,6 +23,8 @@ open class FiservInputFragment : Fragment() {
     private lateinit var paymentMethod: String
     private lateinit var projectId: String
 
+    private var savePaymentCredentials: Boolean = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -32,6 +34,8 @@ open class FiservInputFragment : Fragment() {
 
         projectId = arguments?.serializableExtra<String>(FiservInputView.ARG_PROJECT_ID)
             ?: kotlin.run { activity?.onBackPressedDispatcher?.onBackPressed(); return }
+
+        savePaymentCredentials = arguments?.getBoolean(FiservInputView.ARG_SAVE_PAYMENT_CREDENTIALS, true) ?: true
 
         (requireActivity() as? AppCompatActivity)?.supportActionBar?.title =
             PaymentMethodMetaDataHelper(requireContext()).labelFor(PaymentMethod.valueOf(paymentMethod))
@@ -43,6 +47,7 @@ open class FiservInputFragment : Fragment() {
                 FiservScreen(
                     projectId = projectId,
                     paymentMethod = PaymentMethod.valueOf(paymentMethod),
+                    savePaymentCredentials = savePaymentCredentials,
                     onBackNavigationClick = { activity?.onBackPressedDispatcher?.onBackPressed(); }
                 )
             }
@@ -53,6 +58,7 @@ open class FiservInputFragment : Fragment() {
 fun FiservScreen(
     projectId: String,
     paymentMethod: PaymentMethod,
+    savePaymentCredentials: Boolean,
     onBackNavigationClick: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -76,6 +82,7 @@ fun FiservScreen(
             factory = { ctx ->
                 FiservInputView(ctx)
                     .apply {
+                        setSavePaymentCredentials(savePaymentCredentials)
                         load(
                             projectId,
                             paymentMethod,


### PR DESCRIPTION
Add feature to pass through payment credentials w/o saving.

APPS-1648

### How to test?

* Integrate into a project can make use of it and test the behavior there.


### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [x] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [x] Minified build has been tested _(aka. Release Build)_
- [x] Environments have been taken care of _(Production/Staging)_
- ~~Supported languages have been tested~~
- ~~Light-/Dark-Mode has been tested~~
- [x] Edge-Cases have been tested
- [x] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
