### PR TITLE
Change StateFlow to SharedFlow to fix emitting issues (APPS-1648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+## [0.77.1]
+### Changed
+* core: Change the PaymentCredentialsFlow's StateFlow to be a SharedFlow w/o replaying and state management
+
 ## [0.77.0]
 ### Added
 * core/ui: Add a feature to pass payment credentials w/o saving it into storage

--- a/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsFlow.kt
+++ b/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsFlow.kt
@@ -2,7 +2,8 @@
 
 package io.snabble.sdk.payment
 
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
@@ -20,7 +21,10 @@ internal interface MutableCredentialsFlow {
  */
 object PaymentCredentialsFlow : MutableCredentialsFlow {
 
-    private val _credentialsFlow = MutableStateFlow<PaymentCredentials?>(null)
+    private val _credentialsFlow = MutableSharedFlow<PaymentCredentials?>(
+        replay = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
 
     /**
      * Collect this flow to be notified if payment credentials has been created successfully.

--- a/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsFlow.kt
+++ b/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsFlow.kt
@@ -2,14 +2,15 @@
 
 package io.snabble.sdk.payment
 
-import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 
 internal interface MutableCredentialsFlow {
 
-    fun tryEmitCredentials(credentials: PaymentCredentials): Boolean
+    fun emitCredentials(credentials: PaymentCredentials)
 }
 
 /**
@@ -21,10 +22,7 @@ internal interface MutableCredentialsFlow {
  */
 object PaymentCredentialsFlow : MutableCredentialsFlow {
 
-    private val _credentialsFlow = MutableSharedFlow<PaymentCredentials?>(
-        replay = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
+    private val _credentialsFlow = MutableSharedFlow<PaymentCredentials?>()
 
     /**
      * Collect this flow to be notified if payment credentials has been created successfully.
@@ -32,5 +30,9 @@ object PaymentCredentialsFlow : MutableCredentialsFlow {
      */
     val credentialsFlow: SharedFlow<PaymentCredentials?> = _credentialsFlow.asSharedFlow()
 
-    override fun tryEmitCredentials(credentials: PaymentCredentials): Boolean = _credentialsFlow.tryEmit(credentials)
+    override fun emitCredentials(credentials: PaymentCredentials) {
+        MainScope().launch {
+            _credentialsFlow.emit(credentials)
+        }
+    }
 }

--- a/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsStore.java
+++ b/core/src/main/java/io/snabble/sdk/payment/PaymentCredentialsStore.java
@@ -170,7 +170,7 @@ public class PaymentCredentialsStore {
     }
 
     public synchronized void justEmitCredentials(final PaymentCredentials credentials) {
-        ((MutableCredentialsFlow) PaymentCredentialsFlow.INSTANCE).tryEmitCredentials(credentials);
+        ((MutableCredentialsFlow) PaymentCredentialsFlow.INSTANCE).emitCredentials(credentials);
     }
 
     /**


### PR DESCRIPTION
Change StateFlow to SharedFlow. It should've been a SharedFlow in the first place, mistake.
It's now configured w/o a replay mechanism and the payment credentials are emitted suspending to ensure it's received.

APPS-1648

### How to test?

Integrate into a project can make use of it and test the behavior there.


### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [ ] Changelog is updated
- ~~Documentation is updated~~
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
