### PR TITLE
Add scanner support to accept deposit return vouchers (Apps-1642)

### DIFF
--- a/core/src/main/java/io/snabble/sdk/Project.kt
+++ b/core/src/main/java/io/snabble/sdk/Project.kt
@@ -193,6 +193,13 @@ class Project internal constructor(
     var codeTemplates = emptyList<CodeTemplate>()
         private set
 
+    var depositReturnVoucherProviders = emptyList<DepositReturnVoucherProvider>()
+
+    data class DepositReturnVoucherProvider(
+        val id: String,
+        val templates: List<CodeTemplate>
+    )
+
     /**
      * List of code templates that are used when supplying an existing Product with a different
      * barcode which contains a reduced price
@@ -467,6 +474,22 @@ class Project internal constructor(
             codeTemplates.add(CodeTemplate("default", "{code:*}"))
         }
         this.codeTemplates = codeTemplates
+
+        depositReturnVoucherProviders = jsonObject["depositReturnVoucherProviders"]?.asJsonArray?.mapNotNull { drv ->
+            val id = drv.asJsonObject["id"].asString ?: return
+            val templates = drv.asJsonObject["templates"].asJsonArray?.mapNotNull {
+                it.asJsonObject["template"]?.let {template ->
+                    CodeTemplate(id, template.asString)
+                }
+            } ?: return
+
+            DepositReturnVoucherProvider(
+                id = id,
+                templates = templates
+            )
+        }.orEmpty()
+
+        depositReturnVoucherProviders.xx()
 
         val priceOverrideTemplates = mutableListOf<PriceOverrideTemplate>()
         jsonObject["priceOverrideCodes"]?.asJsonArray?.forEach {

--- a/core/src/main/java/io/snabble/sdk/Project.kt
+++ b/core/src/main/java/io/snabble/sdk/Project.kt
@@ -489,8 +489,6 @@ class Project internal constructor(
             )
         }.orEmpty()
 
-        depositReturnVoucherProviders.xx()
-
         val priceOverrideTemplates = mutableListOf<PriceOverrideTemplate>()
         jsonObject["priceOverrideCodes"]?.asJsonArray?.forEach {
             val priceOverride = it.asJsonObject

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -111,7 +111,8 @@ enum class LineItemType {
     @SerializedName("default") DEFAULT,
     @SerializedName("deposit") DEPOSIT,
     @SerializedName("discount") DISCOUNT,
-    @SerializedName("coupon") COUPON
+    @SerializedName("coupon") COUPON,
+    @SerializedName("depositReturnVoucher") DEPOSIT_RETURN_VOUCHER
 }
 
 enum class CheckState {
@@ -235,6 +236,7 @@ data class LineItem(
     val referenceUnit: String? = null,
     val scannedCode: String? = null,
     val sku: String? = null,
+    @SerializedName("itemId") val itemId: String? = null,
     val totalPrice: Int = 0,
     val type: LineItemType? = null,
     val units: Int? = null,

--- a/core/src/main/java/io/snabble/sdk/codes/ScannedCode.kt
+++ b/core/src/main/java/io/snabble/sdk/codes/ScannedCode.kt
@@ -193,6 +193,15 @@ class ScannedCode private constructor() : Serializable {
                 }
             }
 
+            project.depositReturnVoucherProviders.forEach { drv ->
+                drv.templates.forEach {
+                    val scannedCode: ScannedCode? = it.match(code).buildCode()
+                    if (scannedCode != null) {
+                        matches.add(scannedCode)
+                    }
+                }
+            }
+
             project.priceOverrideTemplates.forEach { priceOverrideTemplate ->
                 val codeTemplate = priceOverrideTemplate.codeTemplate
                 val scannedCode = codeTemplate.match(code).buildCode()

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -626,7 +626,7 @@ class ShoppingCart(
                         BackendCartItem(
                             id = cartItem.id,
                             amount = depositReturnVoucher.amount,
-                            itemID = depositReturnVoucher.itemId,
+                            itemId = depositReturnVoucher.itemId,
                             scannedCode = depositReturnVoucher.scannedCode
                         )
                     )

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -612,6 +612,16 @@ class ShoppingCart(
                     )
                 }
 
+                ItemType.DEPOSIT_RETURN_VOUCHER ->
+                    items.add(
+                        BackendCartItem(
+                            id = cartItem.id,
+                            amount = 1,
+                            itemId = cartItem.lineItem?.itemId,
+                            scannedCode = cartItem.scannedCode?.code
+                        )
+                    )
+
                 else -> Unit
             }
         }
@@ -1040,7 +1050,11 @@ class ShoppingCart(
 
                 coupon != null -> ItemType.COUPON
 
-                lineItem != null -> ItemType.LINE_ITEM
+                lineItem != null -> if (lineItem?.type == LineItemType.DEPOSIT_RETURN_VOUCHER) {
+                    ItemType.DEPOSIT_RETURN_VOUCHER
+                } else {
+                    ItemType.LINE_ITEM
+                }
 
                 else -> null
             }

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/BackendCartItem.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/BackendCartItem.kt
@@ -1,12 +1,15 @@
 package io.snabble.sdk.shoppingcart.data.item
 
 import androidx.annotation.RestrictTo
+import com.google.gson.annotations.SerializedName
+import io.snabble.sdk.checkout.LineItemType
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 data class BackendCartItem(
     val id: String? = null,
     val sku: String? = null,
-    val itemId: String? = null,
+    @JvmField @SerializedName("ItemID") val itemId: String? = null,
+    val type: LineItemType = LineItemType.DEPOSIT_RETURN_VOUCHER,
     @JvmField val scannedCode: String? = null,
     @JvmField val amount: Int = 0,
     @JvmField val weightUnit: String? = null,

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/BackendCartItem.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/BackendCartItem.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RestrictTo
 data class BackendCartItem(
     val id: String? = null,
     val sku: String? = null,
+    val itemId: String? = null,
     @JvmField val scannedCode: String? = null,
     @JvmField val amount: Int = 0,
     @JvmField val weightUnit: String? = null,

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/DepositReturnVoucher.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/DepositReturnVoucher.kt
@@ -1,0 +1,8 @@
+package io.snabble.sdk.shoppingcart.data.item
+
+data class DepositReturnVoucher(
+    val itemId: String,
+    val scannedCode: String,
+    val amount: Int = 1,
+    val type: ItemType = ItemType.DEPOSIT_RETURN_VOUCHER,
+)

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/ItemType.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/ItemType.kt
@@ -5,5 +5,5 @@ package io.snabble.sdk.shoppingcart.data.item
  */
 enum class ItemType {
 
-    PRODUCT, LINE_ITEM, COUPON
+    PRODUCT, LINE_ITEM, COUPON, DEPOSIT_RETURN_VOUCHER
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "34"
 targetSdk = "34"
 minSdk = "21"
-gradlePlugin = "8.6.1"
+gradlePlugin = "8.7.2"
 kotlin = "2.0.20"
 navigation = "2.8.1"
 snabbleSdk = "0.69.6"

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningExtensions.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningExtensions.kt
@@ -1,30 +1,25 @@
 package io.snabble.sdk.ui.scanner
 
 import io.snabble.sdk.Project
-import io.snabble.sdk.checkout.LineItem
-import io.snabble.sdk.checkout.LineItemType
 import io.snabble.sdk.codes.ScannedCode
 import io.snabble.sdk.codes.templates.CodeTemplate
 import io.snabble.sdk.shoppingcart.ShoppingCart
-import java.util.UUID
+import io.snabble.sdk.shoppingcart.data.item.DepositReturnVoucher
 
-fun Project.containsReturnDepositVoucher(list: List<ScannedCode>): Pair<CodeTemplate, ScannedCode>? =
+fun Project.containsReturnDepositVoucher(list: List<ScannedCode>): Pair<CodeTemplate, String>? =
     depositReturnVoucherProviders
         .flatMap { it.templates }
-        .zip(list)
+        .zip(list.mapNotNull { it.code })
         .firstOrNull { (codeTemplates, scannedCodes) ->
-            scannedCodes.code?.startsWith(codeTemplates.pattern.substringBefore("{")) == true
+            scannedCodes.startsWith(codeTemplates.pattern.substringBefore("{"))
         }
 
-fun ShoppingCart.insertDepositReturnVoucherItem(codeTemplate: CodeTemplate, scannedCode: ScannedCode) {
+fun ShoppingCart.insertDepositReturnVoucherItem(codeTemplate: CodeTemplate, scannedCode: String) {
     add(
         newItem(
-            LineItem(
-                id = UUID.randomUUID().toString(),
-                amount = 1,
+            DepositReturnVoucher(
                 itemId = codeTemplate.name,
-                type = LineItemType.DEPOSIT_RETURN_VOUCHER,
-                scannedCode = scannedCode.code
+                scannedCode = scannedCode
             )
         )
     )

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningExtensions.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningExtensions.kt
@@ -1,0 +1,31 @@
+package io.snabble.sdk.ui.scanner
+
+import io.snabble.sdk.Project
+import io.snabble.sdk.checkout.LineItem
+import io.snabble.sdk.checkout.LineItemType
+import io.snabble.sdk.codes.ScannedCode
+import io.snabble.sdk.codes.templates.CodeTemplate
+import io.snabble.sdk.shoppingcart.ShoppingCart
+import java.util.UUID
+
+fun Project.containsReturnDepositVoucher(list: List<ScannedCode>): Pair<CodeTemplate, ScannedCode>? =
+    depositReturnVoucherProviders
+        .flatMap { it.templates }
+        .zip(list)
+        .firstOrNull { (codeTemplates, scannedCodes) ->
+            scannedCodes.code?.startsWith(codeTemplates.pattern.substringBefore("{")) == true
+        }
+
+fun ShoppingCart.insertDepositReturnVoucherItem(codeTemplate: CodeTemplate, scannedCode: ScannedCode) {
+    add(
+        newItem(
+            LineItem(
+                id = UUID.randomUUID().toString(),
+                amount = 1,
+                itemId = codeTemplate.name,
+                type = LineItemType.DEPOSIT_RETURN_VOUCHER,
+                scannedCode = scannedCode.code
+            )
+        )
+    )
+}

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -240,7 +240,7 @@ public class SelfScanningView extends FrameLayout {
     }
 
     private void handleReturnDepositVoucher(List<ScannedCode> scannedCodes) {
-        final kotlin.Pair<CodeTemplate, ScannedCode> codeTemplateScannedCodePair = SelfScanningExtensionsKt.containsReturnDepositVoucher(project, scannedCodes);
+        final kotlin.Pair<CodeTemplate, String> codeTemplateScannedCodePair = SelfScanningExtensionsKt.containsReturnDepositVoucher(project, scannedCodes);
         if (codeTemplateScannedCodePair != null) {
             SelfScanningExtensionsKt.insertDepositReturnVoucherItem(shoppingCart, codeTemplateScannedCodePair.getFirst(), codeTemplateScannedCodePair.getSecond());
             showInfo("Added");

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -243,7 +243,7 @@ public class SelfScanningView extends FrameLayout {
         final kotlin.Pair<CodeTemplate, String> codeTemplateScannedCodePair = SelfScanningExtensionsKt.containsReturnDepositVoucher(project, scannedCodes);
         if (codeTemplateScannedCodePair != null) {
             SelfScanningExtensionsKt.insertDepositReturnVoucherItem(shoppingCart, codeTemplateScannedCodePair.getFirst(), codeTemplateScannedCodePair.getSecond());
-            showInfo("Added");
+            showInfo(getResources().getString(R.string.Snabble_Scanner_DepositReturnVoucher_Added));
         }
     }
 

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -37,6 +37,7 @@ import io.snabble.sdk.Shop;
 import io.snabble.sdk.Snabble;
 import io.snabble.sdk.ViolationNotification;
 import io.snabble.sdk.codes.ScannedCode;
+import io.snabble.sdk.codes.templates.CodeTemplate;
 import io.snabble.sdk.coupons.Coupon;
 import io.snabble.sdk.coupons.CouponCode;
 import io.snabble.sdk.coupons.CouponType;
@@ -192,10 +193,23 @@ public class SelfScanningView extends FrameLayout {
                         resumeBarcodeScanner();
                     }
                 })
-                .setOnProductNotFoundListener(() ->
-                        handleCoupon(scannedCodes, getResources().getString(I18nUtils.getIdentifier(getResources(), R.string.Snabble_Scanner_unknownBarcode))))
+                .setOnProductNotFoundListener(() -> {
+                    final Boolean couponAdded = handleCoupon(scannedCodes);
+                    if (!couponAdded) {
+                        handleReturnDepositVoucher(scannedCodes);
+                    } else {
+                        showWarning(getResources().getString(I18nUtils.getIdentifier(getResources(), R.string.Snabble_Scanner_unknownBarcode)));
+                    }
+                })
                 .setOnNetworkErrorListener(() ->
-                        handleCoupon(scannedCodes, getResources().getString(R.string.Snabble_Scanner_networkError)))
+                {
+                    final Boolean couponAdded = handleCoupon(scannedCodes);
+                    if (!couponAdded) {
+                        handleReturnDepositVoucher(scannedCodes);
+                    } else {
+                        showWarning(getResources().getString(R.string.Snabble_Scanner_networkError));
+                    }
+                })
                 .setOnShelfCodeScannedListener(() ->
                         showWarning(getResources().getString(I18nUtils.getIdentifier(getResources(), R.string.Snabble_Scanner_scannedShelfCode))))
                 .setOnSaleStopListener(() -> new AlertDialog.Builder(getContext())
@@ -225,17 +239,23 @@ public class SelfScanningView extends FrameLayout {
                 .resolve();
     }
 
-    private void handleCoupon(List<ScannedCode> scannedCodes, String failureMessage) {
+    private void handleReturnDepositVoucher(List<ScannedCode> scannedCodes) {
+        final kotlin.Pair<CodeTemplate, ScannedCode> codeTemplateScannedCodePair = SelfScanningExtensionsKt.containsReturnDepositVoucher(project, scannedCodes);
+        if (codeTemplateScannedCodePair != null) {
+            SelfScanningExtensionsKt.insertDepositReturnVoucherItem(shoppingCart, codeTemplateScannedCodePair.getFirst(), codeTemplateScannedCodePair.getSecond());
+            showInfo("Added");
+        }
+    }
+
+    private Boolean handleCoupon(List<ScannedCode> scannedCodes) {
         Pair<Coupon, ScannedCode> coupon = lookupCoupon(scannedCodes);
-        if (coupon == null) {
-            showWarning(failureMessage);
-        } else {
+        if (coupon != null) {
             if (!shoppingCart.containsScannedCode(coupon.second)) {
                 shoppingCart.add(shoppingCart.newItem(coupon.first, coupon.second));
             }
-
             showInfo(getResources().getString(R.string.Snabble_Scanner_couponAdded, coupon.first.getName()));
         }
+        return coupon != null;
     }
 
     private Pair<Coupon, ScannedCode> lookupCoupon(List<ScannedCode> scannedCodes) {
@@ -337,7 +357,7 @@ public class SelfScanningView extends FrameLayout {
             final Project currentProject = Snabble.getInstance().getCheckedInProject().getLatestValue();
 
             RemoteThemingHelper
-                    .changeButtonColorFor(alertDialog,currentProject)
+                    .changeButtonColorFor(alertDialog, currentProject)
                     .show();
 
             input.requestFocus();

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -284,6 +284,7 @@
   <string name="Snabble.Scanner.BundleDialog.headline">Verpackungseinheit auswählen</string>
   <string name="Snabble.Scanner.Camera.accessDenied">Kamerazugriff verweigert</string>
   <string name="Snabble.Scanner.Camera.allowAccess">Entschuldigung, wir benötigen Zugriff auf deine Kamera, um mit ihr Barcodes zu scannen. Bitte erlaube die Nutzung in den Einstellungen und kehre dann hierher zurück.</string>
+  <string name="Snabble.Scanner.DepositReturnVoucher.Added">Pfandbon hinzugefügt</string>
   <string name="Snabble.Scanner.GoToCart.empty">Warenkorb</string>
   <string name="Snabble.Scanner.addCodeAsIs">%s so hinzufügen</string>
   <string name="Snabble.Scanner.addToCart">In den Warenkorb</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -284,6 +284,7 @@
   <string name="Snabble.Scanner.BundleDialog.headline">Choose package</string>
   <string name="Snabble.Scanner.Camera.accessDenied">Camera access denied</string>
   <string name="Snabble.Scanner.Camera.allowAccess">Sorry, we\'ll need to access your camera to scan barcodes. Please allow this in the settings and return here.</string>
+  <string name="Snabble.Scanner.DepositReturnVoucher.Added">Deposit voucher added</string>
   <string name="Snabble.Scanner.GoToCart.empty">Cart</string>
   <string name="Snabble.Scanner.addCodeAsIs">Add %s as-is</string>
   <string name="Snabble.Scanner.addToCart">Add to cart</string>


### PR DESCRIPTION
Deposit return vouchers can now be scanned. This means their accepted and a matching line item is added to the shopping cart. 

This story does not contain violation handling or ui parts.

APPS-1642

### How to test?
Integrate this branch into an app usinng deposit return vouchers and scan it. On Success the default scanner message with added appears.

### Definition of Done

- [x] Issue is linked
- [ ] All requirements of the issue are fulfilled
- [ ] Changelog is updated
- [ ] Documentation is updated
- [ ] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
