### PR TITLE
Improve the exit code on the payment status view (Apps-1795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Added
 ### Changed
-*ui: add safe area as background to the exit code and adjust the brightness if it is shown
+*ui: add quiet zone as background to the exit code and adjust the brightness if it is shown
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Added
 ### Changed
+*ui: add safe area as background to the exit code and adjust the brightness if it is shown
 ### Removed
 ### Fixed
 

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusView.kt
@@ -107,6 +107,7 @@ class PaymentStatusView @JvmOverloads constructor(
 
     init {
         clipChildren = false
+        exitTokenBarcode.removeQuietZone(true)
 
         if (!isInEditMode) {
             project = Snabble.checkedInProject.value

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusView.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.webkit.URLUtil
 import android.widget.Button
@@ -44,6 +45,7 @@ import io.snabble.sdk.ui.payment.SEPACardInputActivity
 import io.snabble.sdk.ui.payment.payone.sepa.form.PayoneSepaActivity
 import io.snabble.sdk.ui.scanner.BarcodeView
 import io.snabble.sdk.ui.telemetry.Telemetry
+import io.snabble.sdk.ui.utils.UIUtils
 import io.snabble.sdk.ui.utils.executeUiAction
 import io.snabble.sdk.ui.utils.getFragmentActivity
 import io.snabble.sdk.ui.utils.observeView
@@ -139,6 +141,8 @@ class PaymentStatusView @JvmOverloads constructor(
             } else {
                 checkout?.abort()
             }
+
+            adjustBrightness(DEFAULT_BRIGHTNESS)
         }
 
         checkout?.state?.observeView(this) {
@@ -335,13 +339,22 @@ class PaymentStatusView @JvmOverloads constructor(
                     exitTokenContainer.isVisible = true
                     exitToken.state = PaymentStatusItemView.State.SUCCESS
                     exitToken.setTitle(resources.getString(R.string.Snabble_PaymentStatus_ExitCode_title))
+                    exitToken.setText(resources.getString(R.string.Snabble_PaymentStatus_ExitCode_openExitGateTimed))
                     exitTokenBarcode.setFormat(format)
                     exitTokenBarcode.setText(it.value)
+                    adjustBrightness(MAX_BRIGHTNESS)
                 } else {
                     exitTokenContainer.isVisible = false
                 }
             }
         }
+    }
+
+    private fun adjustBrightness(value: Float) {
+        val activity = UIUtils.getHostActivity(context)
+        val localLayoutParams: WindowManager.LayoutParams = activity.window.attributes
+        localLayoutParams.screenBrightness = value
+        activity.window.setAttributes(localLayoutParams)
     }
 
     private fun handlePaymentAborted() {
@@ -485,3 +498,6 @@ class PaymentStatusView @JvmOverloads constructor(
         }
     }
 }
+
+private const val MAX_BRIGHTNESS = 0.99f // value of 1.0 is not accepted
+private const val DEFAULT_BRIGHTNESS = -1f

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/BarcodeView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/BarcodeView.java
@@ -51,6 +51,7 @@ public class BarcodeView extends AppCompatImageView {
     private boolean isNumberDisplayEnabled = true;
     private boolean adjustBrightness = true;
     private boolean animateBarcode = true;
+    private boolean removeQuietZone = false;
 
     private Handler uiHandler;
     private int backgroundColor;
@@ -143,6 +144,10 @@ public class BarcodeView extends AppCompatImageView {
         animateBarcode = animate;
     }
 
+    public void removeQuietZone(boolean adjust) {
+        removeQuietZone = adjust;
+    }
+
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
@@ -180,7 +185,7 @@ public class BarcodeView extends AppCompatImageView {
                         Map<EncodeHintType, String> hints = null;
 
                         // Remove the quite zone of the QR code we have enough space in the light mode
-                        if (format == BarcodeFormat.QR_CODE && !isDarkMode) {
+                        if ((format == BarcodeFormat.QR_CODE && !isDarkMode) || removeQuietZone) {
                             hints = new HashMap<>();
                             hints.put(EncodeHintType.MARGIN, "0");
                             border = 0;

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/BarcodeView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/BarcodeView.java
@@ -144,6 +144,10 @@ public class BarcodeView extends AppCompatImageView {
         animateBarcode = animate;
     }
 
+    /**
+     * If set the quiet zone, e.g. the white space around the qr code will be removed.
+     * @param adjust : true for removing the quiet zone false (default) to keep it as it is.
+     */
     public void removeQuietZone(boolean adjust) {
         removeQuietZone = adjust;
     }

--- a/ui/src/main/res/drawable/snabble_barcode_background.xml
+++ b/ui/src/main/res/drawable/snabble_barcode_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+    <corners android:radius="16dp" />
+</shape>

--- a/ui/src/main/res/layout/snabble_view_payment_status.xml
+++ b/ui/src/main/res/layout/snabble_view_payment_status.xml
@@ -124,6 +124,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginVertical="16.dp"
+                        android:padding="16dp"
                         android:layout_gravity="center_horizontal"
                         android:background="@drawable/snabble_barcode_background">
 
@@ -132,7 +133,6 @@
                             android:layout_width="160dp"
                             android:layout_height="160dp"
                             android:layout_gravity="center"
-                            android:layout_margin="16.dp"
                             android:background="@android:color/transparent"
                             android:textAppearance="?attr/textAppearanceBodyLarge"
                             tools:visibility="visible" />

--- a/ui/src/main/res/layout/snabble_view_payment_status.xml
+++ b/ui/src/main/res/layout/snabble_view_payment_status.xml
@@ -120,25 +120,24 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" />
 
-                    <io.snabble.sdk.ui.scanner.BarcodeView
-                        android:id="@+id/exit_token_barcode"
-                        android:layout_width="match_parent"
-                        android:layout_height="120dp"
-                        android:layout_gravity="center"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginEnd="16dp"
-                        android:background="@android:color/transparent"
-                        android:textAppearance="?attr/textAppearanceBodyLarge"
-                        tools:visibility="visible" />
-
-                    <TextView
-                        android:layout_width="match_parent"
+                    <RelativeLayout
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:gravity="center_horizontal"
-                        android:paddingHorizontal="16dp"
-                        android:paddingVertical="8dp"
-                        android:text="@string/Snabble.PaymentStatus.ExitCode.openExitGateTimed"
-                        android:textAppearance="?attr/textAppearanceBodyMedium" />
+                        android:layout_marginVertical="16.dp"
+                        android:layout_gravity="center_horizontal"
+                        android:background="@drawable/snabble_barcode_background">
+
+                        <io.snabble.sdk.ui.scanner.BarcodeView
+                            android:id="@+id/exit_token_barcode"
+                            android:layout_width="160dp"
+                            android:layout_height="160dp"
+                            android:layout_gravity="center"
+                            android:layout_margin="16.dp"
+                            android:background="@android:color/transparent"
+                            android:textAppearance="?attr/textAppearanceBodyLarge"
+                            tools:visibility="visible" />
+                    </RelativeLayout>
+
                 </LinearLayout>
 
                 <io.snabble.sdk.ui.checkout.PaymentStatusItemView


### PR DESCRIPTION
The following changes haven been applied:
* adjust brightness if the exit code is shown
* make the exit code bigger and add a background for better scanning experience (add safezone for scanning)
* move the hint to be the sub title of the section


APPS-1795

### How to test?
Integrate this branch into an app where the exit code is shown on a checkout and and do a checkout.

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [ ] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [x] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [x] Supported languages have been tested
- [x] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [x] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
