### PR TITLE
Fix missing focus on the product search field (Apps-1995)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+* ui: Add missing focus to the product search field after opening the `ProductSearchView`
 
 ## [0.80.1]
 ### Fixed

--- a/ui/src/main/java/io/snabble/sdk/ui/search/ProductSearchView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/search/ProductSearchView.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -80,14 +81,17 @@ open class ProductSearchView @JvmOverloads constructor(
                 var searchedCode by remember { mutableStateOf("") }
 
                 LaunchedEffect(Unit) {
-                    focusRequester.requestFocus()
                     textFieldManager.showKeyboard()
                 }
+
                 Box(modifier = Modifier.padding(8.dp)) {
                     TextInput(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .focusRequester(focusRequester),
+                            .focusRequester(focusRequester)
+                            .onGloballyPositioned {
+                                focusRequester.requestFocus()
+                            },
                         value = searchedCode,
                         label = stringResource(id = R.string.Snabble_Scanner_enterBarcode),
                         keyboardOptions = KeyboardOptions(
@@ -147,7 +151,8 @@ open class ProductSearchView @JvmOverloads constructor(
 
     private fun onSearchUpdated() {
         if (searchableProductAdapter.itemCount == 0 && lastSearchQuery.isNotNullOrBlank() && allowAnyCode) {
-            addCodeAsIs.text = resources.getString(R.string.Snabble_Scanner_addCodeAsIs, lastSearchQuery)
+            addCodeAsIs.text =
+                resources.getString(R.string.Snabble_Scanner_addCodeAsIs, lastSearchQuery)
             addCodeAsIs.visibility = VISIBLE
         } else {
             addCodeAsIs.visibility = GONE

--- a/ui/src/main/java/io/snabble/sdk/ui/search/ProductSearchView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/search/ProductSearchView.kt
@@ -151,8 +151,7 @@ open class ProductSearchView @JvmOverloads constructor(
 
     private fun onSearchUpdated() {
         if (searchableProductAdapter.itemCount == 0 && lastSearchQuery.isNotNullOrBlank() && allowAnyCode) {
-            addCodeAsIs.text =
-                resources.getString(R.string.Snabble_Scanner_addCodeAsIs, lastSearchQuery)
+            addCodeAsIs.text = resources.getString(R.string.Snabble_Scanner_addCodeAsIs, lastSearchQuery)
             addCodeAsIs.visibility = VISIBLE
         } else {
             addCodeAsIs.visibility = GONE


### PR DESCRIPTION
Changed it to request the focus after the widget is positioned to ensure that the focus requester is initialized.


APPS-1995

### How to test?
Launch the app and chechout if the focus works again when searching a product manually.

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [ ] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
