### PR TITLE
Add deposit return voucher states as part of the checkout process (Apps-2040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Added
+* ui/core: Integrate new states for deposit return vouchers into the checkout process and handle them
 ### Changed
 ### Removed
 * ui/core: Remove everything related to the old deposit return voucher feature

--- a/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
@@ -441,6 +441,15 @@ class Checkout @JvmOverloads constructor(
             notifyStateChanged(CheckoutState.PAYMENT_ABORTED)
             return
         }
+        val hasAnyFailedDrvRedemptions =
+            checkoutProcess?.depositReturnVouchers
+                ?.any { it.state == DepositReturnVoucherState.REDEEMING_FAILED }
+                ?: false
+
+        if (hasAnyFailedDrvRedemptions) {
+            notifyStateChanged(CheckoutState.DEPOSIT_RETURN_REDEMPTION_FAILED)
+            return
+        }
 
         Logger.d("Polling for approval state...")
         Logger.d("RoutingTarget = $routingTarget")

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -334,11 +334,37 @@ data class Fulfillment(
         get() = links?.get("self")?.href
 }
 
+data class DepositReturnVoucher(
+    @SerializedName("refersTo")
+    val refersTo: String,
+    @SerializedName("state")
+    val state: DepositReturnVoucherState
+)
+
+enum class DepositReturnVoucherState {
+    @SerializedName("pending")
+    PENDING,
+
+    @SerializedName("redeemed")
+    REDEEMED,
+
+    @SerializedName("redeemingFailed")
+    REDEEMING_FAILED,
+
+    @SerializedName("rolledback")
+    ROLLED_BACK,
+
+    @SerializedName("rollbackFailed")
+    ROLLBACK_FAILED
+}
+
 data class CheckoutProcessResponse(
     val links: Map<String, Href>? = null,
     val checks: List<Check> = emptyList(),
     @SerializedName("orderID")
     val orderId: String? = null,
+    @SerializedName("depositReturnVouchers")
+    val depositReturnVouchers: List<DepositReturnVoucher>? = null,
     val aborted: Boolean = false,
     val paymentMethod: PaymentMethod? = null,
     val paymentInformation: PaymentInformation? = null,

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutState.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutState.kt
@@ -129,4 +129,9 @@ enum class CheckoutState {
      * will not be communicated
      */
     PAYMENT_TRANSFERRED,
+
+    /**
+     * One of the deposit return vouchers added couldn't be redeemed
+     */
+    DEPOSIT_RETURN_REDEMPTION_FAILED
 }

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -1230,12 +1230,10 @@ class ShoppingCart(
         val displayName: String?
             get() = when {
                 lineItem != null -> lineItem?.name
-                else -> if (type == ItemType.COUPON) {
-                    coupon?.name
-                } else if (type == ItemType.DEPOSIT_RETURN_VOUCHER) {
-                    "Leergutbon ${depositReturnVoucher?.scannedCode}"  // TBI: replace it with something better
-                } else {
-                    product?.name
+                else -> when (type) {
+                    ItemType.COUPON -> coupon?.name
+                    ItemType.DEPOSIT_RETURN_VOUCHER -> depositReturnVoucher?.scannedCode
+                    else -> product?.name
                 }
             }
 

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -209,6 +209,16 @@ class ShoppingCart(
     }
 
     /**
+     * Removes a cart item from the cart by its id
+     */
+    fun removeItem(itemId: String) {
+        val index = indexOf(firstOrNull { it?.id == itemId })
+        if (index != -1) {
+            remove(index)
+        }
+    }
+
+    /**
      * The number items in the cart.
      *
      *
@@ -1222,6 +1232,8 @@ class ShoppingCart(
                 lineItem != null -> lineItem?.name
                 else -> if (type == ItemType.COUPON) {
                     coupon?.name
+                } else if (type == ItemType.DEPOSIT_RETURN_VOUCHER) {
+                    "Leergutbon ${depositReturnVoucher?.scannedCode}"  // TBI: replace it with something better
                 } else {
                     product?.name
                 }

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -427,6 +427,10 @@ open class CheckoutBar @JvmOverloads constructor(
                 }
             }
 
+            CheckoutState.DEPOSIT_RETURN_REDEMPTION_FAILED -> {
+                progressDialog.dismiss()
+                //TBI: show Info Dialog here
+            }
             CheckoutState.PAYMENT_ABORTED -> {
                 progressDialog.dismiss()
             }

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -489,9 +489,8 @@ open class CheckoutBar @JvmOverloads constructor(
                 ?: return
 
         val message = failedDepositReturnVouchers
-            .joinToString(separator = "/n") {
-                cart.getByItemId(it.refersTo)?.displayName.toString()
-            }
+            .mapNotNull { cart.getByItemId(it.refersTo)?.displayName }
+            .joinToString(separator = "/n") { it }
 
         AlertDialog.Builder(context)
             .setCancelable(false)

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -488,13 +488,9 @@ open class CheckoutBar @JvmOverloads constructor(
                 ?.filter { it.state == DepositReturnVoucherState.REDEEMING_FAILED }
                 ?: return
 
-        var message = ""
-        failedDepositReturnVouchers
-            .forEachIndexed { index, depositReturnVoucher ->
-                message = "$message${cart.getByItemId(depositReturnVoucher.refersTo)?.displayName}"
-                if (index != failedDepositReturnVouchers.lastIndex){
-                    message = "$message\n"
-                }
+        val message = failedDepositReturnVouchers
+            .joinToString(separator = "/n") {
+                cart.getByItemId(it.refersTo)?.displayName.toString()
             }
 
         AlertDialog.Builder(context)

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -179,6 +179,7 @@ class CheckoutActivity : FragmentActivity() {
                 }
             }
 
+            CheckoutState.DEPOSIT_RETURN_REDEMPTION_FAILED,
             CheckoutState.PAYMENT_ABORTED -> {
                 finish()
                 null

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutHelper.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutHelper.kt
@@ -28,5 +28,6 @@ val CheckoutState.isCheckoutState: Boolean
         CheckoutState.PAYMENT_ABORT_FAILED,
         CheckoutState.PAYMENT_PROCESSING_ERROR,
         CheckoutState.PAYMENT_TRANSFERRED,
+        CheckoutState.DEPOSIT_RETURN_REDEMPTION_FAILED,
         CheckoutState.PAYONE_SEPA_MANDATE_REQUIRED -> true
     }

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/PaymentStatusView.kt
@@ -298,6 +298,11 @@ class PaymentStatusView @JvmOverloads constructor(
                 handlePaymentAborted()
             }
 
+            CheckoutState.DEPOSIT_RETURN_REDEMPTION_FAILED -> {
+                Telemetry.event(Telemetry.Event.CheckoutDepositReturnRedemptionFailed)
+                handlePaymentAborted()
+            }
+
             CheckoutState.PAYMENT_ABORTED -> {
                 Telemetry.event(Telemetry.Event.CheckoutAbortByUser)
                 handlePaymentAborted()

--- a/ui/src/main/java/io/snabble/sdk/ui/telemetry/Telemetry.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/telemetry/Telemetry.java
@@ -7,6 +7,7 @@ public class Telemetry {
         ClickCheckout,
         SelectedPaymentMethod,
         CheckoutSuccessful,
+        CheckoutDepositReturnRedemptionFailed,
         CheckoutDeniedByTooYoung,
         CheckoutDeniedBySupervisor,
         CheckoutDeniedByPaymentProvider,

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="Account.UserDetails.stateSelect">Bitte wählen</string>
   <string name="Snabble.AgeVerification.Failed.message">Einige Artikel in deinem Warenkorb unterliegen einer Altersbeschränkung, du darfst sie leider nicht kaufen.</string>
   <string name="Snabble.AgeVerification.Failed.title">Du bist nicht alt genug</string>
   <string name="Snabble.AgeVerification.Pending.message">Einige Artikel in deinem Warenkorb unterliegen einer Altersbeschränkung. Bitte verifiziere dein Alter, um den Einkauf fortzusetzen.</string>
@@ -342,16 +341,7 @@
   <string name="Snabble.Shop.List.Expand.accessibility">aufklappen</string>
   <string name="Snabble.Shop.List.ShowDetails.accessibility">Shop-Details anzeigen</string>
   <string name="Snabble.Shopping.title">Einkaufen</string>
-  <string name="Snabble.ShoppingCart.DepositReturn.message">Damit der Leergutbon eingelöst werden kann,  fülle deinen Warenkorb mit deinen Wunschprodukten.</string>
-  <string name="Snabble.ShoppingCart.DepositReturn.title">Leergutbon</string>
   <string name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.title">Ungültiger Leergutbon</string>
-  <string name="Snabble.ShoppingCart.Product.Invalid.button">Entfernen</string>
-  <plurals name="Snabble.ShoppingCart.Product.Invalid.message">
-    <item quantity="zero"></item>
-    <item quantity="one">Dieses Produkt kann derzeit leider nicht mit der App bezahlt werden: \n%s\n \n\nBitte bezahle es an der Kassen.</item>
-    <item quantity="other">Diese Produkte können derzeit leider nicht mit der App bezahlt werden: \n%s\n \n\nBitte bezahle diese an der Kassen.</item>
-  </plurals>
-  <string name="Snabble.ShoppingCart.Product.Invalid.title">Ungültiges Produkt</string>
   <string name="Snabble.ShoppingCart.title">Warenkorb</string>
   <string name="Snabble.ShoppingList.AddItem.viaScan">Produkte scannen</string>
   <string name="Snabble.ShoppingList.AddItem.viaVoice">Produkte diktieren</string>

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
+  <string name="Account.UserDetails.stateSelect">Bitte wählen</string>
   <string name="Snabble.AgeVerification.Failed.message">Einige Artikel in deinem Warenkorb unterliegen einer Altersbeschränkung, du darfst sie leider nicht kaufen.</string>
   <string name="Snabble.AgeVerification.Failed.title">Du bist nicht alt genug</string>
   <string name="Snabble.AgeVerification.Pending.message">Einige Artikel in deinem Warenkorb unterliegen einer Altersbeschränkung. Bitte verifiziere dein Alter, um den Einkauf fortzusetzen.</string>
@@ -341,6 +342,16 @@
   <string name="Snabble.Shop.List.Expand.accessibility">aufklappen</string>
   <string name="Snabble.Shop.List.ShowDetails.accessibility">Shop-Details anzeigen</string>
   <string name="Snabble.Shopping.title">Einkaufen</string>
+  <string name="Snabble.ShoppingCart.DepositReturn.message">Damit der Leergutbon eingelöst werden kann,  fülle deinen Warenkorb mit deinen Wunschprodukten.</string>
+  <string name="Snabble.ShoppingCart.DepositReturn.title">Leergutbon</string>
+  <string name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.title">Ungültiger Leergutbon</string>
+  <string name="Snabble.ShoppingCart.Product.Invalid.button">Entfernen</string>
+  <plurals name="Snabble.ShoppingCart.Product.Invalid.message">
+    <item quantity="zero"></item>
+    <item quantity="one">Dieses Produkt kann derzeit leider nicht mit der App bezahlt werden: \n%s\n \n\nBitte bezahle es an der Kassen.</item>
+    <item quantity="other">Diese Produkte können derzeit leider nicht mit der App bezahlt werden: \n%s\n \n\nBitte bezahle diese an der Kassen.</item>
+  </plurals>
+  <string name="Snabble.ShoppingCart.Product.Invalid.title">Ungültiges Produkt</string>
   <string name="Snabble.ShoppingCart.title">Warenkorb</string>
   <string name="Snabble.ShoppingList.AddItem.viaScan">Produkte scannen</string>
   <string name="Snabble.ShoppingList.AddItem.viaVoice">Produkte diktieren</string>
@@ -455,4 +466,10 @@
   <string name="Snabble.save">Speichern</string>
   <string name="Snabble.undo">Rückgängig</string>
   <string name="Snabble.yes">Ja</string>
+  <string name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.button">Entfernen</string>
+  <plurals name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.message">
+    <item quantity="zero"></item>
+    <item quantity="one">Dieser Leergutbon kann derzeit leider nicht in der App eingelöst werden: \n\n%s\n\nBitte versuche es an der Kassen.</item>
+    <item quantity="other">Diese Leergutbon\'s können derzeit leider nicht in der App eingelöst werden: \n\n%s\n\nBitte versuche es an der Kassen.</item>
+  </plurals>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
+  <string name="Account.UserDetails.stateSelect">Pick one</string>
   <string name="Snabble.AgeVerification.Failed.message">Some products in your cart have an age restriction, unfortunately you can\'t purchase them.</string>
   <string name="Snabble.AgeVerification.Failed.title">Age restriction</string>
   <string name="Snabble.AgeVerification.Pending.message">Some products in your cart have an age restriction. Please verify your age before continuing.</string>
@@ -341,6 +342,16 @@
   <string name="Snabble.Shop.List.Expand.accessibility">expand</string>
   <string name="Snabble.Shop.List.ShowDetails.accessibility">Show shop details</string>
   <string name="Snabble.Shopping.title">Shopping</string>
+  <string name="Snabble.ShoppingCart.DepositReturn.message">To redeem your voucher, fill your shopping basket with the products you wish to purchase.</string>
+  <string name="Snabble.ShoppingCart.DepositReturn.title">Deposit voucher</string>
+  <string name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.title">Invalid deposit voucher</string>
+  <string name="Snabble.ShoppingCart.Product.Invalid.button">Remove</string>
+  <plurals name="Snabble.ShoppingCart.Product.Invalid.message">
+    <item quantity="zero"></item>
+    <item quantity="one">Unfortunately, this product cannot currently be paid for with the app: \n%s\n \n\nPlease pay for it at the cash desk.</item>
+    <item quantity="other">Unfortunately, these products cannot currently be paid for with the app: \n%s\n \n\nPlease pay for it at the cash desk.</item>
+  </plurals>
+  <string name="Snabble.ShoppingCart.Product.Invalid.title">Invalid product</string>
   <string name="Snabble.ShoppingCart.title">Shopping Cart</string>
   <string name="Snabble.ShoppingList.AddItem.viaScan">Scan products</string>
   <string name="Snabble.ShoppingList.AddItem.viaVoice">Tell products</string>
@@ -455,4 +466,10 @@
   <string name="Snabble.save">Save</string>
   <string name="Snabble.undo">Undo</string>
   <string name="Snabble.yes">Yes</string>
+  <string name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.button">Remove</string>
+  <plurals name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.message">
+    <item quantity="zero"></item>
+    <item quantity="one">Unfortunately, this deposit voucher cannot currently be redeemed in the app: \n\n%s\n\nPlease try for it at the cash desk.</item>
+    <item quantity="other">Unfortunately, these deposit vouchers cannot currently be redeemed in the app: \n\n%s\n\nPlease try for it at the cash desk.</item>
+  </plurals>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string name="Account.UserDetails.stateSelect">Pick one</string>
   <string name="Snabble.AgeVerification.Failed.message">Some products in your cart have an age restriction, unfortunately you can\'t purchase them.</string>
   <string name="Snabble.AgeVerification.Failed.title">Age restriction</string>
   <string name="Snabble.AgeVerification.Pending.message">Some products in your cart have an age restriction. Please verify your age before continuing.</string>
@@ -342,16 +341,7 @@
   <string name="Snabble.Shop.List.Expand.accessibility">expand</string>
   <string name="Snabble.Shop.List.ShowDetails.accessibility">Show shop details</string>
   <string name="Snabble.Shopping.title">Shopping</string>
-  <string name="Snabble.ShoppingCart.DepositReturn.message">To redeem your voucher, fill your shopping basket with the products you wish to purchase.</string>
-  <string name="Snabble.ShoppingCart.DepositReturn.title">Deposit voucher</string>
   <string name="Snabble.ShoppingCart.DepositVoucher.RedemptionFailed.title">Invalid deposit voucher</string>
-  <string name="Snabble.ShoppingCart.Product.Invalid.button">Remove</string>
-  <plurals name="Snabble.ShoppingCart.Product.Invalid.message">
-    <item quantity="zero"></item>
-    <item quantity="one">Unfortunately, this product cannot currently be paid for with the app: \n%s\n \n\nPlease pay for it at the cash desk.</item>
-    <item quantity="other">Unfortunately, these products cannot currently be paid for with the app: \n%s\n \n\nPlease pay for it at the cash desk.</item>
-  </plurals>
-  <string name="Snabble.ShoppingCart.Product.Invalid.title">Invalid product</string>
   <string name="Snabble.ShoppingCart.title">Shopping Cart</string>
   <string name="Snabble.ShoppingList.AddItem.viaScan">Scan products</string>
   <string name="Snabble.ShoppingList.AddItem.viaVoice">Tell products</string>
@@ -408,7 +398,7 @@
   <string name="Snabble.Shoppingcart.Accessibility.quantity">Quantity</string>
   <string name="Snabble.Shoppingcart.Accessibility.selected">Selected</string>
   <string name="Snabble.Shoppingcart.BuyProducts.now">Pay now</string>
-  <string name="Snabble.Shoppingcart.BuyProducts.one">Buy %1$d product for %2$s</string>
+  <string name="Snabble.Shoppingcart.BuyProducts.one">Buy %1$d product for %2$s</string>1
   <string name="Snabble.Shoppingcart.BuyProducts.selectPaymentMethod">Select payment method</string>
   <string name="Snabble.Shoppingcart.EmptyState.buttonTitle">Scan now</string>
   <string name="Snabble.Shoppingcart.EmptyState.description">Visit a store that supports Snabble and scan the barcodes of products you wish to purchase.</string>


### PR DESCRIPTION
### What's new?

We can now track the state of deposit return vouchers in the checkout process. If a redemption failes, due to whatever reason, we receive a matching state in a new property `depositReturnVouchers` which holds the state for each drv. The state is handled and the user is informed via a Dialog that the reffering deposit return voucher will be removed to proceed with the checkout, e.g. to try again without it.

APPS-2040

### How to test?
Integrate this branch into an app using drv's and scan the product linked in the issue. Add an additional item to get to a positive amount and checkout. -> The dialog should pop up after the checkout failed.

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [x] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [x] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
