### PR TITLE
Add camera permission granted listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Added
+* ui: Add listener to `SelfScanningFragment` to react to camera permission changes
 ### Changed
 ### Removed
 ### Fixed

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningFragment.kt
@@ -58,6 +58,7 @@ open class SelfScanningFragment : BaseFragment(), MenuProvider {
                 createSelfScanningView()
                 requireView().announceForAccessibility(getString(R.string.Snabble_Scanner_Accessibility_eventBackInScanner))
                 explainScanner()
+                onCameraPermissionGrantedListener?.invoke()
             } else {
                 canAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(
                     requireActivity(),
@@ -66,6 +67,8 @@ open class SelfScanningFragment : BaseFragment(), MenuProvider {
                 showPermissionRationale()
             }
         }
+
+    var onCameraPermissionGrantedListener: (() -> Unit)? = null
 
     override fun onCreateActualView(
         inflater: LayoutInflater,

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningFragment.kt
@@ -68,6 +68,9 @@ open class SelfScanningFragment : BaseFragment(), MenuProvider {
             }
         }
 
+    /**
+     * Add a listener to get notified if the camera permission has been granted
+     */
     var onCameraPermissionGrantedListener: (() -> Unit)? = null
 
     override fun onCreateActualView(


### PR DESCRIPTION
Add listener to SelfScanningFragment to react to granted camera permission, to get rid of deprecated features.

APPS-2047

### How to test?
Integrate this branch into an app using the callback and see if it works.

### Definition of Done

- [x] Issue is linked
- [ ] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [x] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
