### PR TITLE
Receive origin type from paymentMethodDescriptor (Apps-888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Added
+* core: Receive origin type from `PaymentMethodDesricptor` in case it is not set by default
 ### Changed
 ### Removed
 ### Fixed

--- a/core/src/main/java/io/snabble/sdk/checkout/DefaultCheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/DefaultCheckoutApi.kt
@@ -11,7 +11,6 @@ import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
-import java.lang.Exception
 import java.net.HttpURLConnection.HTTP_CONFLICT
 import java.net.HttpURLConnection.HTTP_FORBIDDEN
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
@@ -209,6 +208,9 @@ class DefaultCheckoutApi(private val project: Project,
             }
         }
 
+        val originType = paymentCredentials?.type?.originType
+            ?: getOriginTypeFromPaymentMethodDescriptor(paymentMethod = paymentMethod)
+
         val checkoutProcessRequest = CheckoutProcessRequest(
             paymentMethod = paymentMethod,
             signedCheckoutInfo = signedCheckoutInfo,
@@ -217,22 +219,24 @@ class DefaultCheckoutApi(private val project: Project,
             paymentInformation = when (paymentCredentials?.type) {
                 PaymentCredentials.Type.EXTERNAL_BILLING -> {
                     PaymentInformation(
-                        originType = paymentCredentials.type?.originType,
+                        originType = originType,
                         encryptedOrigin = paymentCredentials.encryptedData,
                         subject = paymentCredentials.additionalData["subject"]
                     )
                 }
+
                 PaymentCredentials.Type.CREDIT_CARD_PSD2 -> {
                     PaymentInformation(
-                        originType = paymentCredentials.type?.originType,
+                        originType = originType,
                         encryptedOrigin = paymentCredentials.encryptedData,
                         validUntil = SimpleDateFormat("yyyy/MM/dd").format(Date(paymentCredentials.validTo)),
                         cardNumber = paymentCredentials.obfuscatedId,
                     )
                 }
+
                 PaymentCredentials.Type.GIROPAY -> {
                     PaymentInformation(
-                        originType = paymentCredentials.type?.originType,
+                        originType = originType,
                         encryptedOrigin = paymentCredentials.encryptedData,
                         deviceID = paymentCredentials.additionalData["deviceID"],
                         deviceName = paymentCredentials.additionalData["deviceName"],
@@ -243,7 +247,7 @@ class DefaultCheckoutApi(private val project: Project,
                 null -> null
                 else -> {
                     PaymentInformation(
-                        originType = paymentCredentials.type?.originType,
+                        originType = originType,
                         encryptedOrigin = paymentCredentials.encryptedData
                     )
                 }
@@ -320,7 +324,14 @@ class DefaultCheckoutApi(private val project: Project,
         })
     }
 
+    private fun getOriginTypeFromPaymentMethodDescriptor(paymentMethod: PaymentMethod): String? =
+        project.paymentMethodDescriptors
+            .firstOrNull { it.paymentMethod == paymentMethod }
+            ?.acceptedOriginTypes
+            ?.get(0)
+
     companion object {
+
         private val JSON: MediaType = "application/json".toMediaType()
     }
 }


### PR DESCRIPTION
In case that there is no default (hardcoded) origintype set in the payment method type, we now try to add it from the matching payment method descriptor.

APPS-888

### How to test?
Add logging in the newly added part and try it out in different project with different origintype set for the payment methods (e.g. add this method and do a checkout)

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [x] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
