### PR TITLE
Add changes for zero amount checkout and drv first support (Apps-1939/ 2049)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file.
 * ui: Add UI for deposit return vouchers (APPS-1643)
 * core: Handle invalid items (APPS-2039)
 ### Changed
+* ui: Change button message for a total price of zero and price text color for a negative total price (APPS-1939)
+* core: Handle only a set of pre defined violations (APPS-2049)
 ### Removed
 * ui/core: Remove everything related to the old deposit return voucher feature
+* core: Remove handling an empty list of payment methods in the checkout info as error (APPS-2049)
 ### Fixed
 
 ## [0.80.3]

--- a/core/src/main/java/io/snabble/sdk/checkout/DefaultCheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/DefaultCheckoutApi.kt
@@ -100,11 +100,7 @@ class DefaultCheckoutApi(private val project: Project,
                     ?: shoppingCart.totalPrice
 
                 val availablePaymentMethods = signedCheckoutInfo.getAvailablePaymentMethods()
-                if (availablePaymentMethods.isNotEmpty()) {
-                    checkoutInfoResult?.onSuccess(signedCheckoutInfo, price, availablePaymentMethods)
-                } else {
-                    checkoutInfoResult?.onConnectionError()
-                }
+                checkoutInfoResult?.onSuccess(signedCheckoutInfo, price, availablePaymentMethods)
             }
 
             override fun failure(obj: JsonObject) {

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -733,10 +733,15 @@ class ShoppingCart(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     fun resolveViolations(violations: List<Violation>) {
-        handleCouponViolations(violations)
-        handleDepositReturnVoucherViolations(violations)
+        val validViolations = getValidViolations(violations) ?: return
+        handleCouponViolations(validViolations)
+        handleDepositReturnVoucherViolations(validViolations)
         notifyViolations()
         updatePrices(debounce = false)
+    }
+
+    private fun getValidViolations(violations: List<Violation>): List<Violation>? {
+        return violations.filter { it.type in ViolationType.entries }.ifEmpty { null }
     }
 
     private fun handleDepositReturnVoucherViolations(violations: List<Violation>) {

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -52,6 +52,7 @@ import io.snabble.sdk.ui.utils.observeView
 import io.snabble.sdk.ui.utils.requireFragmentActivity
 import io.snabble.sdk.ui.utils.setOneShotClickListener
 import io.snabble.sdk.utils.Logger
+import io.snabble.sdk.utils.getColorByAttribute
 
 open class CheckoutBar @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
@@ -212,6 +213,11 @@ open class CheckoutBar @JvmOverloads constructor(
             val articlesText = resources.getQuantityText(R.plurals.Snabble_Shoppingcart_numberOfItems, quantity)
             articleCount.text = String.format(articlesText.toString(), quantity)
             priceSum.text = project.priceFormatter.format(price)
+            if (price < 0){
+                context.getColorByAttribute(R.attr.colorError)
+            }else {
+                context.getColorByAttribute(R.attr.colorOnSurface)
+            }
 
             val onlinePaymentAvailable = !cart.availablePaymentMethods.isNullOrEmpty()
             payButton.isEnabled =

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -244,13 +244,23 @@ open class CheckoutBar @JvmOverloads constructor(
                 payButton.isEnabled = true
                 payButton.setText(R.string.Snabble_Shoppingcart_EmptyState_restoreButtonTitle)
             } else {
-                payButton.setText(
-                    I18nUtils.getIdentifierForProject(
-                        resources,
-                        project,
-                        R.string.Snabble_Shoppingcart_BuyProducts_now
+                if (price == 0) {
+                    payButton.setText(
+                        I18nUtils.getIdentifierForProject(
+                            resources,
+                            project,
+                            R.string.Snabble_Shoppingcart_completePurchase
+                        )
                     )
-                )
+                } else {
+                    payButton.setText(
+                        I18nUtils.getIdentifierForProject(
+                            resources,
+                            project,
+                            R.string.Snabble_Shoppingcart_BuyProducts_now
+                        )
+                    )
+                }
             }
         }
     }

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/CheckoutBar.kt
@@ -213,11 +213,13 @@ open class CheckoutBar @JvmOverloads constructor(
             val articlesText = resources.getQuantityText(R.plurals.Snabble_Shoppingcart_numberOfItems, quantity)
             articleCount.text = String.format(articlesText.toString(), quantity)
             priceSum.text = project.priceFormatter.format(price)
-            if (price < 0){
-                context.getColorByAttribute(R.attr.colorError)
-            }else {
-                context.getColorByAttribute(R.attr.colorOnSurface)
-            }
+            priceSum.setTextColor(
+                if (price < 0) {
+                    context.getColorByAttribute(R.attr.colorError)
+                } else {
+                    context.getColorByAttribute(R.attr.colorOnSurface)
+                }
+            )
 
             val onlinePaymentAvailable = !cart.availablePaymentMethods.isNullOrEmpty()
             payButton.isEnabled =

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -406,6 +406,7 @@
   <string name="Snabble.Shoppingcart.EmptyState.title">Dein Warenkorb ist noch leer</string>
   <string name="Snabble.Shoppingcart.articleRemoved">Artikel entfernt</string>
   <string name="Snabble.Shoppingcart.buyProducts">%1$d Artikel für %2$s kaufen</string>
+  <string name="Snabble.Shoppingcart.completePurchase">Einkauf abschließen</string>
   <string name="Snabble.Shoppingcart.coupon">Gutschein</string>
   <string name="Snabble.Shoppingcart.coupons">Gutscheine</string>
   <string name="Snabble.Shoppingcart.deposit">Pfand</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -406,6 +406,7 @@
   <string name="Snabble.Shoppingcart.EmptyState.title">Your shopping cart is empty</string>
   <string name="Snabble.Shoppingcart.articleRemoved">Product removed</string>
   <string name="Snabble.Shoppingcart.buyProducts">Buy %1$d products for %2$s</string>
+  <string name="Snabble.Shoppingcart.completePurchase">Complete purchase</string>
   <string name="Snabble.Shoppingcart.coupon">Coupon</string>
   <string name="Snabble.Shoppingcart.coupons">Coupons</string>
   <string name="Snabble.Shoppingcart.deposit">Deposit</string>


### PR DESCRIPTION
APPS-1939

The color ist adjusted if we have a negative amount for the totals price. Also the label for the button changes if the amount of the total price equals zero. 

APPS-2049

Every signedCheckoutInfo is now handled as a success and only valid violations are supported.

### How to test?
APPS-1939 -> Follow the instructions mentioned in the ticket
APPS-2049 ->  Follow the instructions mentioned in the ticket

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [ ] Changelog is updated
- [ ] Documentation is updated
- [ ] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
