### PR TITLE
Add `fitsSystemWindows` for edge-to-edge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Added
+### Changed
+### Removed
+### Fixed
+
+## [0.80.4]
+### Added
+* ui: Improve edge-to-edge support for apps targing API level 35
 * ui: Add UI for deposit return vouchers (APPS-1643)
 * core: Handle invalid items (APPS-2039)
 * ui/core: Integrate new states for deposit return vouchers into the checkout process and handle them

--- a/ui/src/main/res/layout/snabble_activity_checkout.xml
+++ b/ui/src/main/res/layout/snabble_activity_checkout.xml
@@ -4,6 +4,7 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <!-- Workaround for alignment bug in MaterialToolbar when setting padding -->

--- a/ui/src/main/res/layout/snabble_activity_simple_fragment.xml
+++ b/ui/src/main/res/layout/snabble_activity_simple_fragment.xml
@@ -2,6 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/content"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
 </FrameLayout>

--- a/ui/src/main/res/layout/snabble_activity_simple_fragment_with_toolbar.xml
+++ b/ui/src/main/res/layout/snabble_activity_simple_fragment_with_toolbar.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"


### PR DESCRIPTION
Improve [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) support for apps targeting Android API level 35 by adding `android:fitsSystemWindows="true"` to the layouts used in activities.

### How to test?

* Integrate this branch in our latest App project
* Start Scan&Go and test e.g. this:
  * adding a credit card should not be in bounds
  * the checkout process should now be in bounds

### Definition of Done

- ~~Issue is linked~~
- ~~All requirements of the issue are fulfilled~~
- [x] Changelog is updated
- ~~Documentation is updated~~
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- ~~Environments have been taken care of _(Production/Staging)_~~
- ~~Supported languages have been tested~~
- ~~Light-/Dark-Mode has been tested~~
- [x] Edge-Cases have been tested
- [x] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- ~~Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_~~
