### PR TITLE
add missing prefilled data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Added
+* Add prefilled data to credit card input views
 ### Changed
 ### Removed
 ### Fixed


### PR DESCRIPTION
If an app sets the prefilled data for user related information it will be now applied to any credit card input view.

### How to test?
Integrate this branch into an application using a pre set of data and check if it is applied when trying to add credit card.

Checkout APPS-2126 for more detailed instructions

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)

