### PR TITLE
Fix crash when adding a credit card (APPS-2155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+* ui: fix crash when adding a payment mehtod (APPS-2155)
 
 ## [0.80.5]
 ### Added

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
@@ -52,7 +52,7 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
     private Project project;
     private View emptyState;
     private FloatingActionButton fab;
-    private CircularProgressIndicator progressIndicator;
+    private CircularProgressIndicator circularIndicator;
 
     public PaymentCredentialsListView(Context context) {
         super(context);
@@ -75,7 +75,7 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
         emptyState = findViewById(R.id.empty_state);
         recyclerView = findViewById(R.id.recycler_view);
         fab = findViewById(R.id.fab);
-        progressIndicator = findViewById(R.id.circular_indicator);
+        circularIndicator = findViewById(R.id.circular_indicator);
 
         paymentCredentialsStore = Snabble.getInstance().getPaymentCredentialsStore();
 
@@ -127,7 +127,7 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
 
     public void setProject(Project project) {
         this.project = project;
-        progressIndicator.setVisibility(View.GONE);
+        circularIndicator.setVisibility(View.GONE);
         onChanged();
     }
 
@@ -136,7 +136,7 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
         this.project = project;
 
         entries.clear();
-        progressIndicator.setVisibility(View.GONE);
+        circularIndicator.setVisibility(View.GONE);
         onChanged();
     }
 

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
@@ -102,9 +102,6 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
                         Bundle bundle = new Bundle();
 
                         Project p = project;
-                        if (p == null) {
-                            p = Snabble.getInstance().getCheckedInProject().getValue();
-                        }
                         if (p != null) {
                             bundle.putString(SelectPaymentMethodFragment.ARG_PROJECT_ID, p.getId());
                             dialogFragment.setArguments(bundle);

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListView.java
@@ -100,14 +100,11 @@ public class PaymentCredentialsListView extends FrameLayout implements PaymentCr
                         if (p == null) {
                             p = Snabble.getInstance().getCheckedInProject().getValue();
                         }
-
-                        if (p == null) {
-                            throw new IllegalStateException("Cannot get current project. Did you forget to set the projectId to the PaymentCredentialsListFragment or PaymentCredentialsListView?");
+                        if (p != null) {
+                            bundle.putString(SelectPaymentMethodFragment.ARG_PROJECT_ID, p.getId());
+                            dialogFragment.setArguments(bundle);
+                            dialogFragment.show(((FragmentActivity) activity).getSupportFragmentManager(), null);
                         }
-
-                        bundle.putString(SelectPaymentMethodFragment.ARG_PROJECT_ID, p.getId());
-                        dialogFragment.setArguments(bundle);
-                        dialogFragment.show(((FragmentActivity) activity).getSupportFragmentManager(), null);
                     } else {
                         throw new RuntimeException("Host activity must be a Fragment Activity");
                     }

--- a/ui/src/main/res/layout/snabble_view_payment_credentials_list.xml
+++ b/ui/src/main/res/layout/snabble_view_payment_credentials_list.xml
@@ -11,7 +11,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:visibility="gone"
         app:indicatorSize="48dp"
         android:indeterminate="true"/>
 

--- a/ui/src/main/res/layout/snabble_view_payment_credentials_list.xml
+++ b/ui/src/main/res/layout/snabble_view_payment_credentials_list.xml
@@ -5,6 +5,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/circular_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        app:indicatorSize="48dp"
+        android:indeterminate="true"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -45,6 +55,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
+        android:visibility="gone"
         app:tint="?attr/colorOnSecondary"
         android:src="@drawable/snabble_ic_add"
         android:layout_margin="16dp"/>


### PR DESCRIPTION
instead of throwing an exception and crashing the app a loading indicator is now shown until a project is available.

My assumption is that through the custom lifecycle a race condition happens where the fab button can be clicked while no project is set.


APPS-2155

### How to test?
Integrate the sdk into an app where this view is used and apply this patch

```
Index: ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListFragment.kt b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListFragment.kt
--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListFragment.kt	(revision 46053cc1447b8051bfe86f95ce494f4912b5adab)
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentCredentialsListFragment.kt	(date 1739776443474)
@@ -2,12 +2,15 @@
 
 import android.os.Bundle
 import android.view.View
+import androidx.lifecycle.lifecycleScope
 import io.snabble.sdk.Project
 import io.snabble.sdk.Snabble
 import io.snabble.sdk.payment.PaymentCredentials
 import io.snabble.sdk.ui.BaseFragment
 import io.snabble.sdk.ui.R
 import io.snabble.sdk.ui.utils.serializableExtra
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 open class PaymentCredentialsListFragment : BaseFragment(
     layoutResId = R.layout.snabble_fragment_payment_credentials_list,
@@ -30,6 +33,9 @@
 
     override fun onActualViewCreated(view: View, savedInstanceState: Bundle?) {
         val v = view as PaymentCredentialsListView
-        type?.let { v.show(it, project) } ?: v.setProject(project)
+        lifecycleScope.launch {
+            delay(3000)
+            type?.let { v.show(it, project) } ?: v.setProject(project)
+        }
     }
 }
```

Switch to the branch and check it out again.


### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [ ] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
