### PR TITLE
Fix missing updates for the shopping cart (Apps-2163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Removed
 ### Fixed
+
+## [0.80.8]
+### Fixed
+* ui: Fix missing updates for the shopping cart (APPS-2163)
+
+## [0.80.7]
+### Fixed
 * core: fix payment validation
 
 ## [0.80.6]

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/ShoppingCartViewModel.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/ShoppingCartViewModel.kt
@@ -1,7 +1,10 @@
 package io.snabble.sdk.ui.cart.shoppingcart
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.viewModelScope
 import io.snabble.sdk.PriceFormatter
+import io.snabble.sdk.Project
 import io.snabble.sdk.Snabble
 import io.snabble.sdk.checkout.LineItemType
 import io.snabble.sdk.shoppingcart.ShoppingCart
@@ -15,35 +18,65 @@ import io.snabble.sdk.ui.cart.shoppingcart.product.model.ProductItem
 import io.snabble.sdk.ui.telemetry.Telemetry
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class ShoppingCartViewModel : ViewModel() {
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
 
-    private lateinit var cachedCart: ShoppingCart
+    private var currentCart: ShoppingCart? = null
     private var priceFormatter: PriceFormatter? = null
+    private var project: Project? = null
 
     private val simpleShoppingCartListener = object : SimpleShoppingCartListener() {
         override fun onChanged(cart: ShoppingCart) {
+            currentCart = cart
             updateUiState(cart)
         }
     }
 
     // used to update the cart remote -> do not delete it
     fun updateCart() {
-        updateUiState(cachedCart)
+        currentCart?.let { updateUiState(it) }
     }
 
     init {
-        val project = Snabble.checkedInProject.value
-        val cart = Snabble.checkedInProject.value?.shoppingCart
-        cart?.addListener(simpleShoppingCartListener)
+        project = Snabble.checkedInProject.value
         project?.let {
             priceFormatter = PriceFormatter(it)
-            updateUiState(it.shoppingCart)
+            updateCart(it.shoppingCart)
+            updateOnShoppingCartChange(it)
         }
+        updateOnProjectChange()
+    }
+
+    private fun updateOnShoppingCartChange(project: Project) {
+        viewModelScope.launch {
+            project.shoppingCartFlow.collectLatest {
+                updateCart(it)
+            }
+        }
+    }
+
+    private fun updateOnProjectChange() {
+        viewModelScope.launch {
+            Snabble.checkedInProject.asFlow().filterNotNull().collectLatest {
+                priceFormatter = PriceFormatter(it)
+                updateCart(it.shoppingCart)
+                updateOnShoppingCartChange(it)
+            }
+        }
+    }
+
+    private fun updateCart(shoppingCart: ShoppingCart) {
+        currentCart?.removeListener(simpleShoppingCartListener)
+        currentCart = shoppingCart
+        currentCart?.addListener(simpleShoppingCartListener)
+        updateUiState(shoppingCart)
     }
 
     fun onEvent(event: Event) {
@@ -54,9 +87,9 @@ class ShoppingCartViewModel : ViewModel() {
     }
 
     private fun removeItemFromCart(item: ShoppingCart.Item?, onSuccess: (index: Int) -> Unit) {
-        val index = cachedCart.indexOf(item)
+        val index = currentCart?.indexOf(item) ?: return
         if (index != -1) {
-            cachedCart.remove(index)
+            currentCart?.remove(index)
             Telemetry.event(Telemetry.Event.DeletedFromCart, item?.product)
             onSuccess(index)
         }
@@ -68,8 +101,6 @@ class ShoppingCartViewModel : ViewModel() {
     }
 
     private fun updateUiState(cart: ShoppingCart) {
-        cachedCart = cart
-
         val cartItems: MutableList<CartItem> = mutableListOf()
         with(cart.filterNotNull()) {
             filter { it.type == ItemType.PRODUCT }.let { cartItems.addProducts(it) }
@@ -85,7 +116,7 @@ class ShoppingCartViewModel : ViewModel() {
         cartItems.updatePrices()
         cartItems.sortCartDiscountsToBottom()
 
-        _uiState.update { it.copy(items = cartItems, totalCartPrice = cachedCart.totalPrice) }
+        _uiState.update { it.copy(items = cartItems, totalCartPrice = currentCart?.totalPrice) }
     }
 
     private fun MutableList<CartItem>.addDepositReturnItems(items: List<ShoppingCart.Item>) {


### PR DESCRIPTION
The viewmodel responsible for managing the shopping cart ony keeps track of the initial project. If the project or the shopping cart changes no updates are triggerd leading to wrong shopping carts displayed for not matching shops.

To fix this the viewmodel now tracks shoppingCart changes that occour inside a project (e.g. if a store is switched) and project changes.

APPS-2163

### How to test?


### Definition of Done

- [ ] Issue is linked
- [ ] All requirements of the issue are fulfilled
- [ ] Changelog is updated
- [ ] Documentation is updated
- [ ] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
