### PR TITLE
Add new option for the payment options view (APPS-1915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Added
+*ui: Add new headline option for the payment options (APPS-1915)
 ### Changed
 ### Removed
 ### Fixed

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentOptionsFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentOptionsFragment.kt
@@ -1,9 +1,20 @@
 package io.snabble.sdk.ui.payment
 
+import android.os.Bundle
+import android.view.View
 import io.snabble.sdk.ui.BaseFragment
 import io.snabble.sdk.ui.R
 
 open class PaymentOptionsFragment : BaseFragment(
     layoutResId = R.layout.snabble_fragment_payment_options,
     waitForProject = false
-)
+) {
+    companion object {
+        const val ARG_PAYMENT_OPTIONS_HEADLINE = PaymentOptionsView.ARG_PAYMENT_OPTIONS_HEADLINE
+    }
+
+    override fun onActualViewCreated(view: View, savedInstanceState: Bundle?) {
+        val v = view as PaymentOptionsView
+        arguments?.getString(ARG_PAYMENT_OPTIONS_HEADLINE)?.let { v.setHeadline(it) }
+    }
+}

--- a/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentOptionsView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/payment/PaymentOptionsView.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -25,11 +26,14 @@ import io.snabble.sdk.ui.SnabbleUI
 import io.snabble.sdk.ui.utils.executeUiAction
 import io.snabble.sdk.ui.utils.getFragmentActivity
 import io.snabble.sdk.ui.utils.loadAsset
-import kotlin.collections.set
 
 open class PaymentOptionsView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
+
+    companion object {
+        const val ARG_PAYMENT_OPTIONS_HEADLINE = "headline"
+    }
 
     init {
         inflate(context, R.layout.snabble_payment_options, this)
@@ -59,6 +63,13 @@ open class PaymentOptionsView @JvmOverloads constructor(
                 }
             }
         })
+    }
+
+    fun setHeadline(headline: String) {
+        findViewById<TextView>(R.id.headline).apply {
+            text = headline
+            isVisible = true
+        }
     }
 
     private fun getEntries(): List<Entry> {

--- a/ui/src/main/res/layout/snabble_payment_options.xml
+++ b/ui/src/main/res/layout/snabble_payment_options.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/recycler_view"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/headline"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="16dp"
+        android:textAlignment="center"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>


### PR DESCRIPTION
it is now possible to set a headline for the payment options view the a matching navarg. The headline will only be displayed if set.

APPS-1915

### How to test?
Integrate this branch into an app using the matching view/fragment and set a title via a nav arg.

### Definition of Done

- [ ] Issue is linked
- [ ] All requirements of the issue are fulfilled
- [ ] Changelog is updated
- [ ] Documentation is updated
- [ ] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [ ] Light-/Dark-Mode has been tested
- [ ] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
