### PR TITLE
Cache deposits to avoid flickering behaviour of the shopping cart (APPS-2177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+## [0.80.14]
+### Fixed
+* ui: fix jumping of the shopping cart it an item is used with a deposit (APPS-2177)
+
 ## [0.80.13]
 ### Added
 * ui: Add new headline option for the payment options (APPS-1915)

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -23,6 +23,7 @@ import io.snabble.sdk.shoppingcart.data.cart.BackendCartCustomer
 import io.snabble.sdk.shoppingcart.data.cart.BackendCartRequiredInformation
 import io.snabble.sdk.shoppingcart.data.item.BackendCartItem
 import io.snabble.sdk.shoppingcart.data.item.BackendCartItemType
+import io.snabble.sdk.shoppingcart.data.item.Deposit
 import io.snabble.sdk.shoppingcart.data.item.DepositReturnVoucher
 import io.snabble.sdk.shoppingcart.data.item.ItemType
 import io.snabble.sdk.shoppingcart.data.listener.ShoppingCartListener
@@ -995,6 +996,11 @@ class ShoppingCart(
          * Returns the depositReturnVoucher associated with the shopping cart item.
          */
         var depositReturnVoucher: DepositReturnVoucher? = null
+
+        /**
+         * Returns the deposit associated with the shopping cart item.
+         */
+        var deposit : Deposit? = null
 
         // The local generated UUID of a coupon which which will be used by the backend
         var backendCouponId: String? = null

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartUpdater.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartUpdater.kt
@@ -17,6 +17,7 @@ import io.snabble.sdk.checkout.Price
 import io.snabble.sdk.checkout.SignedCheckoutInfo
 import io.snabble.sdk.checkout.Violation
 import io.snabble.sdk.codes.ScannedCode.Companion.parseDefault
+import io.snabble.sdk.shoppingcart.data.item.Deposit
 import io.snabble.sdk.shoppingcart.data.item.ItemType
 import io.snabble.sdk.utils.GsonHolder
 import io.snabble.sdk.utils.Logger
@@ -160,7 +161,7 @@ internal class ShoppingCartUpdater(
             addLineItemsAsCartItems(filter { it.type == LineItemType.DISCOUNT && it.discountType != "cart" })
 
             addLineItemsAsCartItems(filter { it.type == LineItemType.COUPON })
-            addLineItemsAsCartItems(filter { it.type == LineItemType.DEPOSIT })
+            addDepositToItem(filter { it.type == LineItemType.DEPOSIT })
             addDepositReturnsToVoucher(filter { it.type == LineItemType.DEPOSIT_RETURN })
         }
 
@@ -179,12 +180,20 @@ internal class ShoppingCartUpdater(
         }
     }
 
+    private fun addDepositToItem(deposits: List<LineItem>) {
+        deposits
+            .forEach { deposit ->
+                val item = cart.getByItemId(deposit.refersTo)
+                item?.deposit = Deposit(deposit)
+            }
+    }
+
     private fun addDepositReturnsToVoucher(depositReturnItems: List<LineItem>) {
         depositReturnItems
             .groupBy { it.refersTo }
             .forEach { (refersTo, items) ->
                 val drv = cart.getByItemId(refersTo)
-                drv?.depositReturnVoucher = drv?.depositReturnVoucher?.copy(lineItems = items)
+                drv?.depositReturnVoucher = drv.depositReturnVoucher?.copy(lineItems = items)
             }
     }
 

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/Deposit.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/item/Deposit.kt
@@ -1,0 +1,7 @@
+package io.snabble.sdk.shoppingcart.data.item
+
+import io.snabble.sdk.checkout.LineItem
+
+data class Deposit(
+    val lineItem: LineItem
+)


### PR DESCRIPTION
To avoid the flickering behaviour the deposit is now stored a part of the shopping cart item instead of as an lineitem (since the lineitems are removed on invalidation)

APPS-2177

### How to test?
Launch the sample app check into a store and add a product like a coca cola (5.....).

### Definition of Done

- [x] Issue is linked
- [x] All requirements of the issue are fulfilled
- [x] Changelog is updated
- [x] Documentation is updated
- [x] [Self-Review](https://www.nerdwallet.com/blog/engineering/why-you-should-be-doing-self-reviews/)
- [ ] Review with the Product Owner _(Release-Variante o. Minified Build)_

#### App Tests
- [ ] Minified build has been tested _(aka. Release Build)_
- [ ] Environments have been taken care of _(Production/Staging)_
- [ ] Supported languages have been tested
- [x] Light-/Dark-Mode has been tested
- [x] Edge-Cases have been tested
- [ ] Android API Levels have been taken care of _(minSdk?)_

#### Testing
- [ ] Tests have been written _(aka Unit-Tests, Integration-Tests, ...)_
