### PR TITLE
Resume scanner after adding a cart item and fix the way price modifiers are applied (Apps-2489  and APPS-2491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+## [0.82.2]
+### Fixed
+* Unlock frozen camera after scan
+* Wrong applied price modifiers
+* 
 ## [0.82.1]
 ### Changed
 * Dependency updates

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -263,6 +263,7 @@ data class LineItem(
 data class PriceModifier(
     val name: String? = null,
     val price: Int = 0,
+    val action: String? = null
 )
 
 data class ExitToken(

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCart.kt
@@ -882,6 +882,14 @@ class ShoppingCart(
         }
     }
 
+    fun notifyOnlinePriceUpdate(list: ShoppingCart) {
+        Dispatch.mainThread {
+            listeners?.forEach { listener ->
+                listener.onOnlinePricesUpdated(list)
+            }
+        }
+    }
+
     private fun notifyTaxationChanged(list: ShoppingCart, taxation: Taxation) {
         Dispatch.mainThread {
             listeners?.forEach { listener ->

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartUpdater.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/ShoppingCartUpdater.kt
@@ -177,6 +177,7 @@ internal class ShoppingCartUpdater(
             invalidItemIds = null
             checkLimits()
             notifyPriceUpdate(this)
+            notifyOnlinePriceUpdate(this)
         }
     }
 

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/listener/DefaultShoppingCartListener.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/listener/DefaultShoppingCartListener.kt
@@ -24,6 +24,8 @@ interface DefaultShoppingCartListener : ShoppingCartListener {
     override fun onPricesUpdated(cart: ShoppingCart) {
     }
 
+    override fun onOnlinePricesUpdated(cart: ShoppingCart) {}
+
     override fun onCheckoutLimitReached(cart: ShoppingCart) {
     }
 

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/listener/ShoppingCartListener.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/listener/ShoppingCartListener.kt
@@ -15,6 +15,7 @@ interface ShoppingCartListener {
     fun onItemRemoved(cart: ShoppingCart, item: ShoppingCart.Item, pos: Int)
     fun onProductsUpdated(cart: ShoppingCart)
     fun onPricesUpdated(cart: ShoppingCart)
+    fun onOnlinePricesUpdated(cart: ShoppingCart)
     fun onCheckoutLimitReached(cart: ShoppingCart)
     fun onOnlinePaymentLimitReached(cart: ShoppingCart)
     fun onTaxationChanged(cart: ShoppingCart, taxation: Taxation)

--- a/core/src/main/java/io/snabble/sdk/shoppingcart/data/listener/SimpleShoppingCartListener.kt
+++ b/core/src/main/java/io/snabble/sdk/shoppingcart/data/listener/SimpleShoppingCartListener.kt
@@ -20,6 +20,8 @@ abstract class SimpleShoppingCartListener : ShoppingCartListener {
 
     override fun onPricesUpdated(cart: ShoppingCart) = onChanged(cart)
 
+    override fun onOnlinePricesUpdated(cart: ShoppingCart) = onChanged(cart)
+
     override fun onTaxationChanged(cart: ShoppingCart, taxation: Taxation) = onChanged(cart)
 
     override fun onCheckoutLimitReached(cart: ShoppingCart) {}

--- a/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/model/ProductItem.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/cart/shoppingcart/product/model/ProductItem.kt
@@ -42,7 +42,8 @@ internal data class ProductItem(
                 .sumOf { it.price * quantity }
                 .let(::abs)
         }
-        return totalPrice + depositPrice + sumOfModifierPriceDiscounts
+        return if (item.lineItem?.priceModifiers?.firstOrNull()?.action == "replace") item.lineItem?.price
+            ?: 0 else totalPrice + depositPrice + sumOfModifierPriceDiscounts
     }
 
     fun getPriceWithDiscountsApplied(): Int {

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/ScannerBottomSheetView.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/ScannerBottomSheetView.kt
@@ -143,6 +143,7 @@ class ScannerBottomSheetView @JvmOverloads constructor(
 
     override fun onProductsUpdated(cart: ShoppingCart) {}
     override fun onPricesUpdated(cart: ShoppingCart) = checkSaleStop()
+    override fun onOnlinePricesUpdated(cart: ShoppingCart) {}
     override fun onCheckoutLimitReached(cart: ShoppingCart) {}
     override fun onOnlinePaymentLimitReached(cart: ShoppingCart) {}
     override fun onTaxationChanged(cart: ShoppingCart, taxation: Taxation) {}

--- a/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
+++ b/ui/src/main/java/io/snabble/sdk/ui/scanner/SelfScanningView.java
@@ -8,6 +8,8 @@ import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import android.os.Vibrator;
 import android.text.InputType;
@@ -601,6 +603,13 @@ public class SelfScanningView extends FrameLayout {
         public void onQuantityChanged(@NonNull ShoppingCart cart, ShoppingCart.Item item) {
             showScanMessage(item.getProduct(), false);
         }
+
+        @Override
+        public void onOnlinePricesUpdated(@NonNull ShoppingCart cart) {
+            Handler infoHandler = new Handler(Looper.getMainLooper());
+            infoHandler.postDelayed(() -> resumeBarcodeScanner(), 500);
+        }
+
 
         @Override
         public void onChanged(@NonNull ShoppingCart cart) {


### PR DESCRIPTION
To resume the scanner not right on the spot an new listener method has been implemented. This way the scanner is resumed half a second later than the price are updated from the backend. 
This is done to prevent multiple scan events due to a to fast resuming scanner.