### PR TITLE
Provide authentication fragment if strong customer authorization is activated (APPS-2409)

### DIFF
--- a/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
@@ -503,6 +503,7 @@ class Checkout @JvmOverloads constructor(
             || state == CheckoutState.PAYMENT_PROCESSING
             || (state == CheckoutState.PAYMENT_APPROVED && !areAllFulfillmentsClosed())
             || state == CheckoutState.PAYONE_SEPA_MANDATE_REQUIRED
+            || state == CheckoutState.AUTHENTICATING
         ) {
             scheduleNextPoll()
         }

--- a/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/Checkout.kt
@@ -3,14 +3,18 @@ package io.snabble.sdk.checkout
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
-import io.snabble.sdk.*
+import io.snabble.sdk.FulfillmentState
+import io.snabble.sdk.MutableAccessibleLiveData
+import io.snabble.sdk.PaymentMethod
+import io.snabble.sdk.Product
+import io.snabble.sdk.Project
+import io.snabble.sdk.Snabble
 import io.snabble.sdk.Snabble.instance
 import io.snabble.sdk.payment.PaymentCredentials
 import io.snabble.sdk.shoppingcart.ShoppingCart
 import io.snabble.sdk.utils.Dispatch
 import io.snabble.sdk.utils.Logger
 import java.io.File
-import java.util.*
 import java.util.concurrent.Future
 
 class Checkout @JvmOverloads constructor(
@@ -578,6 +582,10 @@ class Checkout @JvmOverloads constructor(
 
                 CheckState.PROCESSING -> {
                     notifyStateChanged(CheckoutState.PAYMENT_PROCESSING)
+                }
+
+                CheckState.AUTHENTICATING -> {
+                    notifyStateChanged(CheckoutState.AUTHENTICATING)
                 }
 
                 CheckState.SUCCESSFUL -> {

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutApi.kt
@@ -119,6 +119,7 @@ enum class CheckState {
     @SerializedName("unauthorized") UNAUTHORIZED,
     @SerializedName("pending") PENDING,
     @SerializedName("processing")  PROCESSING,
+    @SerializedName("authenticating") AUTHENTICATING,
     @SerializedName("successful") SUCCESSFUL,
     @SerializedName("transferred") TRANSFERRED,
     @SerializedName("failed") FAILED
@@ -385,6 +386,9 @@ data class CheckoutProcessResponse(
 
     val authorizePaymentLink: String?
         get() = links?.get("authorizePayment")?.href
+
+    val paymentRedirect: String?
+        get() = links?.get("paymentRedirect")?.href
 
     val originCandidateLink: String?
         get() = paymentResult?.originCandidateLink

--- a/core/src/main/java/io/snabble/sdk/checkout/CheckoutState.kt
+++ b/core/src/main/java/io/snabble/sdk/checkout/CheckoutState.kt
@@ -27,6 +27,12 @@ enum class CheckoutState {
     VERIFYING_PAYMENT_METHOD,
 
     /**
+     * The payment need further authentication.
+     * Use the paymentRedirect link provided for further authentication.
+     */
+    AUTHENTICATING,
+
+    /**
      * Age needs to be verified
      */
     REQUEST_VERIFY_AGE,

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/AuthenticationFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/AuthenticationFragment.kt
@@ -1,26 +1,20 @@
 package io.snabble.sdk.ui.checkout
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.fragment.app.Fragment
 import io.snabble.sdk.Snabble
+import io.snabble.sdk.ui.BaseFragment
 import io.snabble.sdk.ui.R
 import io.snabble.sdk.utils.Logger
 
-class AuthenticationFragment : Fragment() {
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-        inflater.inflate(R.layout.snabble_fragment_authentication, container, false)
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+class AuthenticationFragment : BaseFragment(R.layout.snabble_fragment_authentication) {
+    override fun onActualViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onActualViewCreated(view, savedInstanceState)
 
         val currentCheckout = Snabble.checkedInProject.value?.checkout
 
@@ -53,8 +47,8 @@ class AuthenticationFragment : Fragment() {
                     SUCCESS,
                     ERROR,
                     BACK -> {
-                        // Check if the we need to do something, since the checkout activity is observing the state and should handle redirects itself
-                        // If not we need something like popBackstack and maybe notify the user with a toast
+                        // No need to pop it since we're polling for the checkout state in the activity
+                        // and navigate away as soon the get an update state
                         return true
                     }
                 }

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/AuthenticationFragment.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/AuthenticationFragment.kt
@@ -1,0 +1,85 @@
+package io.snabble.sdk.ui.checkout
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.fragment.app.Fragment
+import io.snabble.sdk.Snabble
+import io.snabble.sdk.ui.R
+import io.snabble.sdk.utils.Logger
+
+class AuthenticationFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+        inflater.inflate(R.layout.snabble_fragment_authentication, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val currentCheckout = Snabble.checkedInProject.value?.checkout
+
+        // Setup your views here after inflation
+        val webview = view.findViewById<WebView>(R.id.authentication_webview)
+        webview.setupCookies()
+
+        // Configure WebView settings
+        webview.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            loadWithOverviewMode = true
+            useWideViewPort = true
+            setSupportZoom(true)
+            builtInZoomControls = true
+            displayZoomControls = false
+
+            // Additional cookie-related settings
+            databaseEnabled = true
+            cacheMode = WebSettings.LOAD_DEFAULT
+        }
+
+        webview.webViewClient = object : WebViewClient() {
+            override fun onReceivedError(view: WebView?, errorCode: Int, description: String?, failingUrl: String?) {
+                Logger.d("onReceivedError $failingUrl")
+            }
+
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                when (request.url.toString()) {
+                    SUCCESS,
+                    ERROR,
+                    BACK -> {
+                        // Check if the we need to do something, since the checkout activity is observing the state and should handle redirects itself
+                        // If not we need something like popBackstack and maybe notify the user with a toast
+                        return true
+                    }
+                }
+                return super.shouldOverrideUrlLoading(view, request)
+            }
+        }
+
+        val redirectUrl = currentCheckout?.checkoutProcess?.paymentRedirect
+        redirectUrl?.let {
+            webview.loadUrl(it)
+        }
+    }
+
+    // Extension function for cleaner code
+    fun WebView.setupCookies() {
+        val cookieManager = CookieManager.getInstance()
+        cookieManager.setAcceptCookie(true)
+        cookieManager.setAcceptThirdPartyCookies(this, true)
+        cookieManager.flush()
+    }
+
+    private companion object {
+
+        const val SUCCESS = "snabble://payone/success"
+        const val ERROR = "snabble://payone/error"
+        const val BACK = "snabble://payone/back"
+    }
+}

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutActivity.kt
@@ -214,6 +214,8 @@ class CheckoutActivity : FragmentActivity() {
                 }
             }
 
+            CheckoutState.AUTHENTICATING -> R.id.snabble_nav_authentication
+
             CheckoutState.DEPOSIT_RETURN_REDEMPTION_FAILED,
             CheckoutState.PAYMENT_ABORTED -> {
                 finish()

--- a/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutHelper.kt
+++ b/ui/src/main/java/io/snabble/sdk/ui/checkout/CheckoutHelper.kt
@@ -22,6 +22,7 @@ val CheckoutState.isCheckoutState: Boolean
         CheckoutState.WAIT_FOR_GATEKEEPER,
         CheckoutState.WAIT_FOR_APPROVAL,
         CheckoutState.PAYMENT_PROCESSING,
+        CheckoutState.AUTHENTICATING,
         CheckoutState.PAYMENT_APPROVED,
         CheckoutState.DENIED_TOO_YOUNG,
         CheckoutState.DENIED_BY_PAYMENT_PROVIDER,

--- a/ui/src/main/res/layout/snabble_fragment_authentication.xml
+++ b/ui/src/main/res/layout/snabble_fragment_authentication.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <WebView
+        android:id="@+id/authentication_webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/ui/src/main/res/navigation/snabble_nav_checkout.xml
+++ b/ui/src/main/res/navigation/snabble_nav_checkout.xml
@@ -38,6 +38,12 @@
         android:label="@string/Snabble.Checkout.title" />
 
     <fragment
+        android:id="@+id/snabble_nav_authentication"
+        android:name="io.snabble.sdk.ui.checkout.AuthenticationFragment"
+        android:label="@string/Snabble.Checkout.title"
+        />
+
+    <fragment
         android:id="@+id/snabble_nav_payment_payone_sepa_mandate"
         android:name="io.snabble.sdk.ui.payment.payone.sepa.mandate.PayoneSepaMandateFragment"
         android:label="@string/Snabble.Checkout.title" />

--- a/ui/src/main/res/navigation/snabble_nav_checkout.xml
+++ b/ui/src/main/res/navigation/snabble_nav_checkout.xml
@@ -40,8 +40,7 @@
     <fragment
         android:id="@+id/snabble_nav_authentication"
         android:name="io.snabble.sdk.ui.checkout.AuthenticationFragment"
-        android:label="@string/Snabble.Checkout.title"
-        />
+        android:label="@string/Snabble.Checkout.title" />
 
     <fragment
         android:id="@+id/snabble_nav_payment_payone_sepa_mandate"


### PR DESCRIPTION
Sometimes additional authentication is required during the payment process. To handle this a new checkout state has been added an redirects to an extra authentication fragment.

APPS-2409

### How to test?
See Issue instructions